### PR TITLE
fix(batch): respect --finish-mode in integration phase; propagate PR failures

### DIFF
--- a/scripts/genie-session
+++ b/scripts/genie-session
@@ -506,25 +506,24 @@ session_integrate_pr() {
     fi
 
     # Create PR via gh or print manual instructions
+    local remote_url
+    remote_url=$(git -C "$repo_root" remote get-url origin 2>/dev/null)
     if command -v gh >/dev/null 2>&1; then
         local pr_url
-        pr_url=$(cd "$repo_root" && gh pr create \
+        if ! pr_url=$(cd "$repo_root" && gh pr create \
             --base "$default_branch" \
             --head "$branch" \
             --title "$(_gs_pr_title "$item")" \
-            --body "$(_gs_pr_body "$item")" 2>/dev/null) || true
+            --body "$(_gs_pr_body "$item")"); then
+            _gs_error "Failed to create PR for branch: $branch"
+            _gs_log "  Branch pushed — create manually: ${remote_url%.git}/compare/$branch"
+            return 1
+        fi
 
         if [[ -n "${pr_url:-}" ]]; then
             echo "$pr_url"
-        else
-            local remote_url
-            remote_url=$(git -C "$repo_root" remote get-url origin 2>/dev/null)
-            _gs_log "PR creation failed. Branch pushed — create PR manually:"
-            _gs_log "  ${remote_url%.git}/compare/$branch"
         fi
     else
-        local remote_url
-        remote_url=$(git -C "$repo_root" remote get-url origin 2>/dev/null)
         _gs_log "Branch pushed. gh CLI not available — create PR manually:"
         _gs_log "  ${remote_url%.git}/compare/$branch"
     fi

--- a/scripts/genies
+++ b/scripts/genies
@@ -2215,7 +2215,11 @@ run_batch_parallel() {
             "${conflict_items[@]+"${conflict_items[@]}"}"
 
         # Reconcile shared state (backlog statuses, current_work.md)
-        reconcile_batch_state
+        # Skip when --leave-branch: branches haven't been integrated yet,
+        # so marking items done would corrupt state before human review.
+        if [[ "$FINISH_MODE" != "--leave-branch" ]]; then
+            reconcile_batch_state
+        fi
     fi
 
     if [[ $failed -gt 0 || $merge_conflicts -gt 0 ]]; then

--- a/scripts/genies
+++ b/scripts/genies
@@ -1296,14 +1296,21 @@ print_batch_dry_run() {
         fi
     done
 
-    if [[ "$PARALLEL_JOBS" -gt 0 && "$TRUNK_MODE" == "true" ]]; then
-        log_info "Mode: parallel ($PARALLEL_JOBS workers, trunk-based, worktrees)"
-    elif [[ "$PARALLEL_JOBS" -gt 0 ]]; then
-        log_info "Mode: parallel ($PARALLEL_JOBS workers, PR-based, worktrees)"
-    elif [[ "$TRUNK_MODE" == "true" ]]; then
-        log_info "Mode: sequential (trunk-based, worktrees)"
+    local finish_label
+    if [[ "$TRUNK_MODE" == "true" ]]; then
+        finish_label="trunk-based"
+    elif [[ "$FINISH_MODE" == "--leave-branch" ]]; then
+        finish_label="branch-preserve"
+    elif [[ "$FINISH_MODE" == "--merge" ]]; then
+        finish_label="merge-based"
     else
-        log_info "Mode: sequential (worktrees)"
+        finish_label="PR-based"
+    fi
+
+    if [[ "$PARALLEL_JOBS" -gt 0 ]]; then
+        log_info "Mode: parallel ($PARALLEL_JOBS workers, ${finish_label}, worktrees)"
+    else
+        log_info "Mode: sequential (${finish_label}, worktrees)"
     fi
     log_info "(dry run — not executing)"
 }
@@ -1324,7 +1331,9 @@ print_batch_summary() {
     log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     log_info "BATCH SUMMARY"
     log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    log_info "Succeeded: $succeeded"
+    local succeeded_label="Succeeded"
+    [[ "${FINISH_MODE:-}" == "--leave-branch" ]] && succeeded_label="Branches preserved"
+    log_info "${succeeded_label}: $succeeded"
     log_info "Failed:    $failed"
     log_info "Duration:  ${duration_mins}m"
 
@@ -1374,7 +1383,9 @@ print_batch_parallel_summary() {
     log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     log_info "BATCH SUMMARY (parallel)"
     log_info "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    log_info "Succeeded:       $succeeded"
+    local succeeded_label="Succeeded"
+    [[ "${FINISH_MODE:-}" == "--leave-branch" ]] && succeeded_label="Branches preserved"
+    log_info "${succeeded_label}:       $succeeded"
     log_info "Failed:          $failed"
     log_info "Merge conflicts: $conflicts"
     log_info "Duration:        ${duration_mins}m"
@@ -1382,7 +1393,7 @@ print_batch_parallel_summary() {
 
     if [[ ${#succeeded_items[@]} -gt 0 ]]; then
         log_info ""
-        log_info "Succeeded:"
+        log_info "${succeeded_label}:"
         for item in "${succeeded_items[@]}"; do
             log_info "  $(basename "$item" .md)"
         done

--- a/scripts/genies
+++ b/scripts/genies
@@ -1510,7 +1510,9 @@ run_batch_sequential() {
         if [[ $ec -eq 0 ]]; then
             # Integrate the worktree branch
             local integrate_ec=0
-            if [[ "$TRUNK_MODE" == "true" ]]; then
+            if [[ "$FINISH_MODE" == "--leave-branch" ]]; then
+                log_info "Branch preserved: $slug (--finish-mode --leave-branch)"
+            elif [[ "$TRUNK_MODE" == "true" ]]; then
                 session_integrate_trunk "$slug" || integrate_ec=$?
             else
                 session_integrate_pr "$slug" || integrate_ec=$?
@@ -2119,65 +2121,69 @@ run_batch_parallel() {
 
     # ── Integration phase: serialize merges/PRs ──
     if [[ ${#succeeded_items[@]} -gt 0 ]]; then
-        log_info "Integration phase: ${#succeeded_items[@]} items to integrate"
+        if [[ "$FINISH_MODE" == "--leave-branch" ]]; then
+            log_info "Branches preserved (--finish-mode --leave-branch): ${succeeded_slugs[*]+"${succeeded_slugs[*]}"}"
+        else
+            log_info "Integration phase: ${#succeeded_items[@]} items to integrate"
 
-        local integrate_idx=0
-        while [[ $integrate_idx -lt ${#succeeded_items[@]} ]]; do
-            local slug="${succeeded_slugs[$integrate_idx]}"
-            local input="${succeeded_items[$integrate_idx]}"
-            log_info "Integrating: $slug"
+            local integrate_idx=0
+            while [[ $integrate_idx -lt ${#succeeded_items[@]} ]]; do
+                local slug="${succeeded_slugs[$integrate_idx]}"
+                local input="${succeeded_items[$integrate_idx]}"
+                log_info "Integrating: $slug"
 
-            if [[ "$TRUNK_MODE" == "true" ]]; then
-                session_integrate_trunk "$slug"
-                local ec=$?
-                case $ec in
-                    0)
-                        log_info "Merged to trunk: $slug"
-                        ;;
-                    1)
-                        failed=$((failed + 1))
-                        failed_items+=("$input")
-                        succeeded=$((succeeded - 1))
-                        log_error "No branch found: $slug"
-                        ;;
-                    2)
-                        merge_conflicts=$((merge_conflicts + 1))
-                        conflict_items+=("$input")
-                        succeeded=$((succeeded - 1))
-                        log_error "Rebase conflict: $slug"
-                        ;;
-                    3)
-                        failed=$((failed + 1))
-                        failed_items+=("$input")
-                        succeeded=$((succeeded - 1))
-                        log_error "Checkout failed: $slug"
-                        ;;
-                    4)
-                        failed=$((failed + 1))
-                        failed_items+=("$input")
-                        succeeded=$((succeeded - 1))
-                        log_error "Merge failed (not fast-forwardable): $slug"
-                        ;;
-                    *)
-                        failed=$((failed + 1))
-                        failed_items+=("$input")
-                        succeeded=$((succeeded - 1))
-                        log_error "Integration failed (exit $ec): $slug"
-                        ;;
-                esac
-            else
-                if session_integrate_pr "$slug"; then
-                    log_info "PR created: $slug"
+                if [[ "$TRUNK_MODE" == "true" ]]; then
+                    session_integrate_trunk "$slug"
+                    local ec=$?
+                    case $ec in
+                        0)
+                            log_info "Merged to trunk: $slug"
+                            ;;
+                        1)
+                            failed=$((failed + 1))
+                            failed_items+=("$input")
+                            succeeded=$((succeeded - 1))
+                            log_error "No branch found: $slug"
+                            ;;
+                        2)
+                            merge_conflicts=$((merge_conflicts + 1))
+                            conflict_items+=("$input")
+                            succeeded=$((succeeded - 1))
+                            log_error "Rebase conflict: $slug"
+                            ;;
+                        3)
+                            failed=$((failed + 1))
+                            failed_items+=("$input")
+                            succeeded=$((succeeded - 1))
+                            log_error "Checkout failed: $slug"
+                            ;;
+                        4)
+                            failed=$((failed + 1))
+                            failed_items+=("$input")
+                            succeeded=$((succeeded - 1))
+                            log_error "Merge failed (not fast-forwardable): $slug"
+                            ;;
+                        *)
+                            failed=$((failed + 1))
+                            failed_items+=("$input")
+                            succeeded=$((succeeded - 1))
+                            log_error "Integration failed (exit $ec): $slug"
+                            ;;
+                    esac
                 else
-                    failed=$((failed + 1))
-                    failed_items+=("$input")
-                    log_error "PR creation failed: $slug"
-                    succeeded=$((succeeded - 1))
+                    if session_integrate_pr "$slug"; then
+                        log_info "PR created: $slug"
+                    else
+                        failed=$((failed + 1))
+                        failed_items+=("$input")
+                        log_error "PR creation failed: $slug"
+                        succeeded=$((succeeded - 1))
+                    fi
                 fi
-            fi
 
-            integrate_idx=$((integrate_idx + 1))
-        done
+                integrate_idx=$((integrate_idx + 1))
+            done
+        fi
     fi
 
     # Print summary

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -3551,6 +3551,12 @@ _orig_print_batch_summary=$(declare -f print_batch_summary)
 _saved_SELF="$SELF"
 _saved_FINISH_MODE="${FINISH_MODE:-}"
 _saved_TRUNK_MODE="${TRUNK_MODE:-}"
+_saved_THROUGH_PHASE="${THROUGH_PHASE:-}"
+_saved_VERBOSE_LOGGING="${VERBOSE_LOGGING:-}"
+_saved_SKIP_PERMISSIONS="${SKIP_PERMISSIONS:-}"
+_saved_REVIEW_CYCLES="${REVIEW_CYCLES:-}"
+_saved_CONTINUE_ON_FAILURE="${CONTINUE_ON_FAILURE:-}"
+_saved_LOG_DIR="${LOG_DIR:-}"
 _saved_BATCH_ITEMS=("${BATCH_ITEMS[@]+"${BATCH_ITEMS[@]}"}")
 
 # Install spies
@@ -3592,6 +3598,12 @@ assert_eq "true" "$_seq_pr_called" \
 SELF="$_saved_SELF"
 FINISH_MODE="$_saved_FINISH_MODE"
 TRUNK_MODE="$_saved_TRUNK_MODE"
+THROUGH_PHASE="$_saved_THROUGH_PHASE"
+VERBOSE_LOGGING="$_saved_VERBOSE_LOGGING"
+SKIP_PERMISSIONS="$_saved_SKIP_PERMISSIONS"
+REVIEW_CYCLES="$_saved_REVIEW_CYCLES"
+CONTINUE_ON_FAILURE="$_saved_CONTINUE_ON_FAILURE"
+LOG_DIR="$_saved_LOG_DIR"
 BATCH_ITEMS=("${_saved_BATCH_ITEMS[@]+"${_saved_BATCH_ITEMS[@]}"}")
 eval "$_orig_integrate_pr"
 eval "$_orig_integrate_trunk"
@@ -3619,6 +3631,11 @@ _orig_reconcile_batch_state=$(declare -f reconcile_batch_state)
 _saved_SELF="$SELF"
 _saved_FINISH_MODE="${FINISH_MODE:-}"
 _saved_TRUNK_MODE="${TRUNK_MODE:-}"
+_saved_THROUGH_PHASE="${THROUGH_PHASE:-}"
+_saved_VERBOSE_LOGGING="${VERBOSE_LOGGING:-}"
+_saved_SKIP_PERMISSIONS="${SKIP_PERMISSIONS:-}"
+_saved_REVIEW_CYCLES="${REVIEW_CYCLES:-}"
+_saved_LOG_DIR="${LOG_DIR:-}"
 _saved_BATCH_ITEMS=("${BATCH_ITEMS[@]+"${BATCH_ITEMS[@]}"}")
 _saved_PARALLEL_JOBS="${PARALLEL_JOBS:-0}"
 
@@ -3663,6 +3680,11 @@ assert_eq "true" "$_par_pr_called" \
 SELF="$_saved_SELF"
 FINISH_MODE="$_saved_FINISH_MODE"
 TRUNK_MODE="$_saved_TRUNK_MODE"
+THROUGH_PHASE="$_saved_THROUGH_PHASE"
+VERBOSE_LOGGING="$_saved_VERBOSE_LOGGING"
+SKIP_PERMISSIONS="$_saved_SKIP_PERMISSIONS"
+REVIEW_CYCLES="$_saved_REVIEW_CYCLES"
+LOG_DIR="$_saved_LOG_DIR"
 BATCH_ITEMS=("${_saved_BATCH_ITEMS[@]+"${_saved_BATCH_ITEMS[@]}"}")
 PARALLEL_JOBS="$_saved_PARALLEL_JOBS"
 eval "$_orig_integrate_pr"

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -3532,6 +3532,94 @@ teardown_temp
 echo ""
 echo "--- batch integration: FINISH_MODE ---"
 
+# ── Dry run label tests ──
+
+_saved_FINISH_MODE_dr="${FINISH_MODE:-}"
+_saved_TRUNK_MODE_dr="${TRUNK_MODE:-}"
+_saved_PARALLEL_JOBS_dr="${PARALLEL_JOBS:-0}"
+_saved_BATCH_ITEMS_dr=("${BATCH_ITEMS[@]+"${BATCH_ITEMS[@]}"}")
+_orig_log_info=$(declare -f log_info)
+
+_log_capture=""
+log_info() { _log_capture="${_log_capture}$*"$'\n'; }
+BATCH_ITEMS=("deliver:fake-item.md")
+
+# Test: dry run shows branch-preserve for parallel --leave-branch
+FINISH_MODE="--leave-branch"; TRUNK_MODE="false"; PARALLEL_JOBS=2
+_log_capture=""
+print_batch_dry_run
+assert_contains "$_log_capture" "branch-preserve" \
+    "dry run: parallel --leave-branch shows branch-preserve"
+
+# Test: dry run shows PR-based for parallel --pr
+FINISH_MODE="--pr"; TRUNK_MODE="false"; PARALLEL_JOBS=2
+_log_capture=""
+print_batch_dry_run
+assert_contains "$_log_capture" "PR-based" \
+    "dry run: parallel --pr shows PR-based"
+
+# Test: dry run shows branch-preserve for sequential --leave-branch
+FINISH_MODE="--leave-branch"; TRUNK_MODE="false"; PARALLEL_JOBS=0
+_log_capture=""
+print_batch_dry_run
+assert_contains "$_log_capture" "branch-preserve" \
+    "dry run: sequential --leave-branch shows branch-preserve"
+
+# Test: dry run still shows trunk-based when --trunk regardless of --finish-mode
+FINISH_MODE="--leave-branch"; TRUNK_MODE="true"; PARALLEL_JOBS=0
+_log_capture=""
+print_batch_dry_run
+assert_contains "$_log_capture" "trunk-based" \
+    "dry run: --trunk takes precedence over --leave-branch label"
+
+# Restore
+FINISH_MODE="$_saved_FINISH_MODE_dr"
+TRUNK_MODE="$_saved_TRUNK_MODE_dr"
+PARALLEL_JOBS="$_saved_PARALLEL_JOBS_dr"
+BATCH_ITEMS=("${_saved_BATCH_ITEMS_dr[@]+"${_saved_BATCH_ITEMS_dr[@]}"}")
+eval "$_orig_log_info"
+
+# ── Summary label tests ──
+
+_saved_FINISH_MODE_sl="${FINISH_MODE:-}"
+_orig_log_info_sl=$(declare -f log_info)
+
+_log_capture=""
+log_info() { _log_capture="${_log_capture}$*"$'\n'; }
+_start=$(date +%s)
+
+# Test: print_batch_summary shows "Branches preserved" when --leave-branch
+FINISH_MODE="--leave-branch"
+_log_capture=""
+print_batch_summary 3 0 "$_start"
+assert_contains "$_log_capture" "Branches preserved" \
+    "print_batch_summary: --leave-branch shows Branches preserved label"
+
+# Test: print_batch_summary shows "Succeeded" when --pr
+FINISH_MODE="--pr"
+_log_capture=""
+print_batch_summary 3 0 "$_start"
+assert_contains "$_log_capture" "Succeeded" \
+    "print_batch_summary: --pr shows Succeeded label"
+
+# Test: print_batch_parallel_summary shows "Branches preserved" when --leave-branch
+FINISH_MODE="--leave-branch"
+_log_capture=""
+print_batch_parallel_summary 3 0 0 "$_start" "item-a.md" "---" "---"
+assert_contains "$_log_capture" "Branches preserved" \
+    "print_batch_parallel_summary: --leave-branch shows Branches preserved label"
+
+# Test: print_batch_parallel_summary shows "Succeeded" when --pr
+FINISH_MODE="--pr"
+_log_capture=""
+print_batch_parallel_summary 3 0 0 "$_start" "item-a.md" "---" "---"
+assert_contains "$_log_capture" "Succeeded" \
+    "print_batch_parallel_summary: --pr shows Succeeded label"
+
+# Restore
+FINISH_MODE="$_saved_FINISH_MODE_sl"
+eval "$_orig_log_info_sl"
+
 # ── Sequential batch behavioral tests ──
 
 setup_temp

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -3524,6 +3524,156 @@ assert_eq "false" "$skip_applied" "AC-3: non-file input skips fallback"
 teardown_temp
 
 # ═══════════════════════════════════════════════
+# Category 44: batch integration respects FINISH_MODE (issue #8)
+# Behavioral tests: mock session integration functions, run actual batch code,
+# verify which integration paths are (or aren't) called.
+# ═══════════════════════════════════════════════
+
+echo ""
+echo "--- batch integration: FINISH_MODE ---"
+
+# ── Sequential batch behavioral tests ──
+
+setup_temp
+echo "---" > "$TEMP_DIR/fake-item.md"
+
+# Create mock $SELF that exits 0 (simulates a successful single-item worker)
+cat > "$TEMP_DIR/mock-self" << 'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+chmod +x "$TEMP_DIR/mock-self"
+
+# Save originals
+_orig_integrate_pr=$(declare -f session_integrate_pr)
+_orig_integrate_trunk=$(declare -f session_integrate_trunk)
+_orig_print_batch_summary=$(declare -f print_batch_summary)
+_saved_SELF="$SELF"
+_saved_FINISH_MODE="${FINISH_MODE:-}"
+_saved_TRUNK_MODE="${TRUNK_MODE:-}"
+_saved_BATCH_ITEMS=("${BATCH_ITEMS[@]+"${BATCH_ITEMS[@]}"}")
+
+# Install spies
+_seq_pr_called="false"
+_seq_trunk_called="false"
+session_integrate_pr()   { _seq_pr_called="true";    return 0; }
+session_integrate_trunk() { _seq_trunk_called="true"; return 0; }
+print_batch_summary() { :; }
+
+# Arrange
+SELF="$TEMP_DIR/mock-self"
+FINISH_MODE="--leave-branch"
+TRUNK_MODE="false"
+THROUGH_PHASE="discern"
+VERBOSE_LOGGING="false"
+SKIP_PERMISSIONS="true"
+REVIEW_CYCLES=1
+CONTINUE_ON_FAILURE="false"
+LOG_DIR=""
+BATCH_ITEMS=("deliver:$TEMP_DIR/fake-item.md")
+
+# Act
+run_batch_sequential >/dev/null 2>&1
+
+# Assert
+assert_eq "false" "$_seq_pr_called" \
+    "sequential batch: --leave-branch does not call session_integrate_pr"
+assert_eq "false" "$_seq_trunk_called" \
+    "sequential batch: --leave-branch does not call session_integrate_trunk"
+
+# Verify it DOES call session_integrate_pr when FINISH_MODE=--pr
+FINISH_MODE="--pr"
+_seq_pr_called="false"
+run_batch_sequential >/dev/null 2>&1
+assert_eq "true" "$_seq_pr_called" \
+    "sequential batch: --pr calls session_integrate_pr"
+
+# Restore
+SELF="$_saved_SELF"
+FINISH_MODE="$_saved_FINISH_MODE"
+TRUNK_MODE="$_saved_TRUNK_MODE"
+BATCH_ITEMS=("${_saved_BATCH_ITEMS[@]+"${_saved_BATCH_ITEMS[@]}"}")
+eval "$_orig_integrate_pr"
+eval "$_orig_integrate_trunk"
+eval "$_orig_print_batch_summary"
+
+teardown_temp
+
+# ── Parallel batch behavioral tests ──
+
+setup_temp
+echo "---" > "$TEMP_DIR/fake-item.md"
+cat > "$TEMP_DIR/mock-self" << 'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+chmod +x "$TEMP_DIR/mock-self"
+mkdir -p "$TEMP_DIR/logs"
+
+# Save originals
+_orig_integrate_pr=$(declare -f session_integrate_pr)
+_orig_integrate_trunk=$(declare -f session_integrate_trunk)
+_orig_print_batch_parallel_summary=$(declare -f print_batch_parallel_summary)
+_orig_write_batch_manifest=$(declare -f write_batch_manifest)
+_orig_reconcile_batch_state=$(declare -f reconcile_batch_state)
+_saved_SELF="$SELF"
+_saved_FINISH_MODE="${FINISH_MODE:-}"
+_saved_TRUNK_MODE="${TRUNK_MODE:-}"
+_saved_BATCH_ITEMS=("${BATCH_ITEMS[@]+"${BATCH_ITEMS[@]}"}")
+_saved_PARALLEL_JOBS="${PARALLEL_JOBS:-0}"
+
+# Install spies
+_par_pr_called="false"
+_par_trunk_called="false"
+session_integrate_pr()   { _par_pr_called="true";    return 0; }
+session_integrate_trunk() { _par_trunk_called="true"; return 0; }
+print_batch_parallel_summary() { :; }
+write_batch_manifest() { :; }
+reconcile_batch_state() { :; }
+
+# Arrange
+SELF="$TEMP_DIR/mock-self"
+FINISH_MODE="--leave-branch"
+TRUNK_MODE="false"
+THROUGH_PHASE="discern"
+VERBOSE_LOGGING="false"
+SKIP_PERMISSIONS="true"
+REVIEW_CYCLES=1
+LOG_DIR="$TEMP_DIR/logs"
+PARALLEL_JOBS=1
+BATCH_ITEMS=("deliver:$TEMP_DIR/fake-item.md")
+
+# Act
+run_batch_parallel >/dev/null 2>&1
+
+# Assert
+assert_eq "false" "$_par_pr_called" \
+    "parallel batch: --leave-branch does not call session_integrate_pr"
+assert_eq "false" "$_par_trunk_called" \
+    "parallel batch: --leave-branch does not call session_integrate_trunk"
+
+# Verify it DOES call session_integrate_pr when FINISH_MODE=--pr
+FINISH_MODE="--pr"
+_par_pr_called="false"
+run_batch_parallel >/dev/null 2>&1
+assert_eq "true" "$_par_pr_called" \
+    "parallel batch: --pr calls session_integrate_pr"
+
+# Restore
+SELF="$_saved_SELF"
+FINISH_MODE="$_saved_FINISH_MODE"
+TRUNK_MODE="$_saved_TRUNK_MODE"
+BATCH_ITEMS=("${_saved_BATCH_ITEMS[@]+"${_saved_BATCH_ITEMS[@]}"}")
+PARALLEL_JOBS="$_saved_PARALLEL_JOBS"
+eval "$_orig_integrate_pr"
+eval "$_orig_integrate_trunk"
+eval "$_orig_print_batch_parallel_summary"
+eval "$_orig_write_batch_manifest"
+eval "$_orig_reconcile_batch_state"
+
+teardown_temp
+
+# ═══════════════════════════════════════════════
 # Summary
 # ═══════════════════════════════════════════════
 

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -3730,11 +3730,12 @@ _saved_PARALLEL_JOBS="${PARALLEL_JOBS:-0}"
 # Install spies
 _par_pr_called="false"
 _par_trunk_called="false"
-session_integrate_pr()   { _par_pr_called="true";    return 0; }
-session_integrate_trunk() { _par_trunk_called="true"; return 0; }
+_par_reconcile_called="false"
+session_integrate_pr()    { _par_pr_called="true";        return 0; }
+session_integrate_trunk()  { _par_trunk_called="true";     return 0; }
+reconcile_batch_state()    { _par_reconcile_called="true"; return 0; }
 print_batch_parallel_summary() { :; }
 write_batch_manifest() { :; }
-reconcile_batch_state() { :; }
 
 # Arrange
 SELF="$TEMP_DIR/mock-self"
@@ -3756,6 +3757,8 @@ assert_eq "false" "$_par_pr_called" \
     "parallel batch: --leave-branch does not call session_integrate_pr"
 assert_eq "false" "$_par_trunk_called" \
     "parallel batch: --leave-branch does not call session_integrate_trunk"
+assert_eq "false" "$_par_reconcile_called" \
+    "parallel batch: --leave-branch does not call reconcile_batch_state"
 
 # Verify it DOES call session_integrate_pr when FINISH_MODE=--pr
 FINISH_MODE="--pr"

--- a/tests/test_session.sh
+++ b/tests/test_session.sh
@@ -829,10 +829,11 @@ setup
 # Test: cleanup succeeds when worktree directory was manually deleted (stale reference)
 # Arrange — create worktree, then manually rm -rf the directory to simulate crash
 SAVED_DIR="$(pwd)"
-cd "$TEST_REPO" || exit
-git worktree add "../${REPO_NAME}--P0-stale-item" -b "genie/P0-stale-item-deliver" main -q 2>/dev/null
+_repo_name="$(basename "$MAIN_REPO")"
+cd "$MAIN_REPO" || exit
+git worktree add "../${_repo_name}--P0-stale-item" -b "genie/P0-stale-item-deliver" main -q 2>/dev/null
 # Simulate crash: remove the directory without git knowing
-rm -rf "../${REPO_NAME}--P0-stale-item"
+rm -rf "../${_repo_name}--P0-stale-item"
 # Verify the stale reference exists (git thinks worktree is still there)
 stale_count=$(git worktree list --porcelain 2>/dev/null | grep -c "worktree.*P0-stale-item" || true)
 assert_eq "1" "$stale_count" "session_cleanup_item: stale worktree reference exists before cleanup"
@@ -850,6 +851,41 @@ else
 fi
 
 cd "$SAVED_DIR" || true
+teardown
+
+# ─────────────────────────────────────────────
+# Test: session_integrate_pr propagates gh pr create failure (issue #8)
+# ─────────────────────────────────────────────
+echo ""
+echo "--- session_integrate_pr: failure propagation ---"
+
+setup
+
+# Arrange — create session with a commit
+cd "$MAIN_REPO" && session_start "failing-pr-item" "deliver" >/dev/null 2>&1
+git -C "$TEMP_DIR/main-repo--failing-pr-item" config user.email "test@test.com"
+git -C "$TEMP_DIR/main-repo--failing-pr-item" config user.name "Test"
+echo "feature" > "$TEMP_DIR/main-repo--failing-pr-item/feature.txt"
+git -C "$TEMP_DIR/main-repo--failing-pr-item" add feature.txt
+git -C "$TEMP_DIR/main-repo--failing-pr-item" commit -m "add feature" -q
+
+# Arrange — mock gh that exits non-zero (simulates gh pr create failure)
+MOCK_BIN_FAIL="$TEMP_DIR/mock-bin-failing"
+mkdir -p "$MOCK_BIN_FAIL"
+cat > "$MOCK_BIN_FAIL/gh" << 'MOCK_GH'
+#!/bin/bash
+exit 1
+MOCK_GH
+chmod +x "$MOCK_BIN_FAIL/gh"
+
+# Act
+ec=0
+cd "$MAIN_REPO" && PATH="$MOCK_BIN_FAIL:$PATH" session_integrate_pr "failing-pr-item" >/dev/null 2>&1 || ec=$?
+
+# Assert
+assert_exit_code "1" "$ec" \
+    "session_integrate_pr: returns non-zero when gh pr create fails"
+
 teardown
 
 # ─────────────────────────────────────────────


### PR DESCRIPTION
> **Stack:** This is PR 1 of 3 — merges into `main` first.
> - **#12** (this PR) → `main`
> - #13 (worktree setup) → stacks on #12
> - #14 (status surface) → stacks on #13

Reopened for maintainer review — identical to #11, which was accidentally merged before sign-off.

## Summary

- **`--finish-mode --leave-branch` was silently ignored in batch mode** — both sequential and parallel batch integration phases only checked `TRUNK_MODE`, never `FINISH_MODE`. Branches were always integrated regardless of the flag.
- **`session_integrate_pr` swallowed `gh pr create` failures** — a `|| true` caused silent exit-0 even when PR creation failed, so batch runs reported "PR created" for items where no PR was actually opened. Root cause of the "only one PR created out of 7" symptom in issue #8.

## Changes

- `scripts/genies` (`run_batch_sequential`): skip integration block when `FINISH_MODE=--leave-branch`
- `scripts/genies` (`run_batch_parallel`): skip integration phase entirely when `FINISH_MODE=--leave-branch`; fix indentation of else block
- `scripts/genies` (`reconcile_batch_state`): gate behind `FINISH_MODE != --leave-branch` to prevent premature `done` status mutation
- `scripts/genies` (`print_batch_dry_run`, `print_batch_summary`, `print_batch_parallel_summary`): reflect `--leave-branch` in labels
- `scripts/genie-session` (`session_integrate_pr`): drop `2>/dev/null` so gh errors surface; restore compare URL hint on failure path; propagate `gh pr create` failures (return 1)
- `tests/test_run_pdlc.sh`: add Category 44 — behavioral tests using spy pattern that mock session integration functions and assert call behavior under each `FINISH_MODE`
- `tests/test_session.sh`: add failure propagation test for `session_integrate_pr`; fix pre-existing `TEST_REPO`/`REPO_NAME` undefined-variable bug causing early exit

## Test plan

- [x] `--leave-branch` skips integration in sequential batch
- [x] `--leave-branch` skips integration in parallel batch
- [x] `reconcile_batch_state` not called when `--leave-branch`
- [x] Dry run label reflects finish mode
- [x] Summary shows "Branches preserved" for `--leave-branch`
- [x] `session_integrate_pr` returns non-zero when `gh pr create` fails
- [x] All 379 tests in `test_run_pdlc.sh` + `test_session.sh` pass

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)