### PR TITLE
feat(worktree): auto-run environment setup after worktree creation

### DIFF
--- a/scripts/genies
+++ b/scripts/genies
@@ -1125,6 +1125,50 @@ if [[ -f "$GENIE_SESSION" ]]; then
     source "$GENIE_SESSION"
 fi
 
+# Run post-worktree-creation environment setup.
+# Option A: project-defined .genie/setup.sh (takes precedence, runs unconditionally)
+# Option B: detect package manager lockfile and install deps when node_modules absent
+worktree_run_setup() {
+    local worktree_dir="$1"
+
+    # Option A: project-defined setup script
+    local setup_script="$worktree_dir/.genie/setup.sh"
+    if [[ -f "$setup_script" && -x "$setup_script" ]]; then
+        log_info "Running worktree setup: .genie/setup.sh"
+        if ! (cd "$worktree_dir" && bash "$setup_script"); then
+            log_error "Worktree setup script failed: .genie/setup.sh"
+            return 1
+        fi
+        return 0
+    fi
+
+    # Option B: detect package manager lockfile, install if node_modules absent
+    if [[ -d "$worktree_dir/node_modules" ]]; then
+        return 0
+    fi
+
+    local pm_cmd=""
+    if [[ -f "$worktree_dir/pnpm-lock.yaml" ]]; then
+        pm_cmd="pnpm install --frozen-lockfile"
+    elif [[ -f "$worktree_dir/package-lock.json" ]]; then
+        pm_cmd="npm ci"
+    elif [[ -f "$worktree_dir/yarn.lock" ]]; then
+        pm_cmd="yarn install --frozen-lockfile"
+    elif [[ -f "$worktree_dir/bun.lockb" ]]; then
+        pm_cmd="bun install --frozen-lockfile"
+    fi
+
+    if [[ -n "$pm_cmd" ]]; then
+        log_info "Installing dependencies in worktree: $pm_cmd"
+        if ! (cd "$worktree_dir" && $pm_cmd >/dev/null 2>&1); then
+            log_error "Dependency install failed in worktree: $pm_cmd"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
 worktree_setup() {
     local item_slug="$1"
     # Clean up any prior failed attempt (worktree + branch) before creating new
@@ -1134,6 +1178,7 @@ worktree_setup() {
         log_error "Failed to create worktree for $item_slug"
         return 1
     }
+    worktree_run_setup "$worktree_path" || return 1
     echo "$worktree_path"
     return 0
 }

--- a/scripts/genies
+++ b/scripts/genies
@@ -1147,21 +1147,23 @@ worktree_run_setup() {
         return 0
     fi
 
-    local pm_cmd=""
+    local pm_cmd=()
     if [[ -f "$worktree_dir/pnpm-lock.yaml" ]]; then
-        pm_cmd="pnpm install --frozen-lockfile"
+        pm_cmd=(pnpm install --frozen-lockfile)
     elif [[ -f "$worktree_dir/package-lock.json" ]]; then
-        pm_cmd="npm ci"
+        pm_cmd=(npm ci)
     elif [[ -f "$worktree_dir/yarn.lock" ]]; then
-        pm_cmd="yarn install --frozen-lockfile"
-    elif [[ -f "$worktree_dir/bun.lockb" ]]; then
-        pm_cmd="bun install --frozen-lockfile"
+        pm_cmd=(yarn install --frozen-lockfile)
+    elif [[ -f "$worktree_dir/bun.lock" || -f "$worktree_dir/bun.lockb" ]]; then
+        pm_cmd=(bun install --frozen-lockfile)
     fi
 
-    if [[ -n "$pm_cmd" ]]; then
-        log_info "Installing dependencies in worktree: $pm_cmd"
-        if ! (cd "$worktree_dir" && $pm_cmd >/dev/null 2>&1); then
-            log_error "Dependency install failed in worktree: $pm_cmd"
+    if [[ ${#pm_cmd[@]} -gt 0 ]]; then
+        log_info "Installing dependencies in worktree: ${pm_cmd[*]}"
+        local install_err
+        if ! install_err=$(cd "$worktree_dir" && "${pm_cmd[@]}" 2>&1 >/dev/null); then
+            log_error "Dependency install failed in worktree: ${pm_cmd[*]}"
+            [[ -n "$install_err" ]] && log_error "$install_err"
             return 1
         fi
     fi
@@ -1178,7 +1180,10 @@ worktree_setup() {
         log_error "Failed to create worktree for $item_slug"
         return 1
     }
-    worktree_run_setup "$worktree_path" || return 1
+    worktree_run_setup "$worktree_path" || {
+        log_info "Worktree left at: $worktree_path — re-run to clean up or call session_cleanup_item"
+        return 1
+    }
     echo "$worktree_path"
     return 0
 }

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -3915,6 +3915,71 @@ assert_file_not_exists "$TEMP_DIR/pnpm_called" "worktree_run_setup: setup.sh tak
 export PATH="$_saved_PATH"
 teardown_temp
 
+# Test: bun.lockb triggers bun install
+setup_temp
+touch "$TEMP_DIR/bun.lockb"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\necho "$@" > "%s/bun_args"\ntouch "%s/bun_called"\n' "$TEMP_DIR" "$TEMP_DIR" > "$TEMP_DIR/bin/bun"
+chmod +x "$TEMP_DIR/bin/bun"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1
+assert_file_exists "$TEMP_DIR/bun_called" "worktree_run_setup: runs bun install for bun.lockb"
+bun_args=$(cat "$TEMP_DIR/bun_args" 2>/dev/null || echo "")
+assert_contains "$bun_args" "frozen-lockfile" "worktree_run_setup: bun.lockb uses --frozen-lockfile"
+export PATH="$_saved_PATH"
+teardown_temp
+
+# Test: bun.lock (Bun 1.2+ TOML format) triggers bun install
+setup_temp
+touch "$TEMP_DIR/bun.lock"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\ntouch "%s/bun_called"\n' "$TEMP_DIR" > "$TEMP_DIR/bin/bun"
+chmod +x "$TEMP_DIR/bin/bun"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1
+assert_file_exists "$TEMP_DIR/bun_called" "worktree_run_setup: runs bun install for bun.lock"
+export PATH="$_saved_PATH"
+teardown_temp
+
+# Test: install failure surfaces stderr content in error log
+setup_temp
+touch "$TEMP_DIR/pnpm-lock.yaml"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\necho "peer conflict: react@18 vs react@17" >&2\nexit 1\n' > "$TEMP_DIR/bin/pnpm"
+chmod +x "$TEMP_DIR/bin/pnpm"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+_log_errors=""
+_orig_log_error_wrs=$(declare -f log_error)
+log_error() { _log_errors="${_log_errors}$*"$'\n'; }
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || true
+assert_contains "$_log_errors" "peer conflict" "worktree_run_setup: install failure surfaces stderr content"
+eval "$_orig_log_error_wrs"
+export PATH="$_saved_PATH"
+teardown_temp
+
+# Test: worktree_setup logs dangling path when setup fails
+setup_temp
+_log_info_msgs=""
+_orig_log_info_wrs=$(declare -f log_info)
+log_info() { _log_info_msgs="${_log_info_msgs}$*"$'\n'; }
+_orig_worktree_run_setup=$(declare -f worktree_run_setup)
+_fake_path="$TEMP_DIR/fake-worktree"
+worktree_run_setup() { return 1; }
+_orig_session_start_ws=$(declare -f session_start)
+session_start() { echo "$_fake_path"; }
+_orig_session_cleanup_item_ws=$(declare -f session_cleanup_item)
+session_cleanup_item() { return 0; }
+worktree_setup "test-item" >/dev/null 2>&1 || true
+assert_contains "$_log_info_msgs" "$_fake_path" "worktree_setup: logs dangling worktree path on setup failure"
+eval "$_orig_log_info_wrs"
+eval "$_orig_worktree_run_setup"
+eval "$_orig_session_start_ws"
+eval "$_orig_session_cleanup_item_ws"
+teardown_temp
+
 # ═══════════════════════════════════════════════
 # Summary
 # ═══════════════════════════════════════════════

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -3784,6 +3784,135 @@ eval "$_orig_print_batch_parallel_summary"
 eval "$_orig_write_batch_manifest"
 eval "$_orig_reconcile_batch_state"
 
+# Category 45: worktree_run_setup (issue #7)
+# ═══════════════════════════════════════════════
+
+echo ""
+echo "--- worktree_run_setup ---"
+
+# Test: returns 0 with no setup script and no lockfiles
+setup_temp
+ec=0
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || ec=$?
+assert_eq "0" "$ec" "worktree_run_setup: returns 0 when nothing to do"
+teardown_temp
+
+# Test: runs .genie/setup.sh when present and executable
+setup_temp
+mkdir -p "$TEMP_DIR/.genie"
+cat > "$TEMP_DIR/.genie/setup.sh" << 'SETUP'
+#!/bin/bash
+echo "setup ran" > "$WORKTREE_SETUP_MARKER"
+SETUP
+chmod +x "$TEMP_DIR/.genie/setup.sh"
+WORKTREE_SETUP_MARKER="$TEMP_DIR/setup.ran"
+export WORKTREE_SETUP_MARKER
+ec=0
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || ec=$?
+assert_eq "0" "$ec" "worktree_run_setup: returns 0 when setup.sh succeeds"
+assert_file_exists "$TEMP_DIR/setup.ran" "worktree_run_setup: executes .genie/setup.sh"
+unset WORKTREE_SETUP_MARKER
+teardown_temp
+
+# Test: returns 1 when .genie/setup.sh exits non-zero
+setup_temp
+mkdir -p "$TEMP_DIR/.genie"
+printf '#!/bin/bash\nexit 1\n' > "$TEMP_DIR/.genie/setup.sh"
+chmod +x "$TEMP_DIR/.genie/setup.sh"
+ec=0
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || ec=$?
+assert_eq "1" "$ec" "worktree_run_setup: returns 1 when setup.sh fails"
+teardown_temp
+
+# Test: skips .genie/setup.sh when not executable (falls through to lockfile detection)
+setup_temp
+mkdir -p "$TEMP_DIR/.genie"
+printf '#!/bin/bash\necho "should not run"\n' > "$TEMP_DIR/.genie/setup.sh"
+# Not chmod +x — not executable
+touch "$TEMP_DIR/pnpm-lock.yaml"
+mkdir -p "$TEMP_DIR/node_modules"  # already installed — skip install
+ec=0
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || ec=$?
+assert_eq "0" "$ec" "worktree_run_setup: non-executable setup.sh falls through to lockfile path"
+teardown_temp
+
+# Test: detects pnpm-lock.yaml and runs pnpm install when node_modules absent
+setup_temp
+touch "$TEMP_DIR/pnpm-lock.yaml"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\necho "pnpm $*" > "%s/pnpm_called"\n' "$TEMP_DIR" > "$TEMP_DIR/bin/pnpm"
+chmod +x "$TEMP_DIR/bin/pnpm"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+ec=0
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || ec=$?
+assert_eq "0" "$ec" "worktree_run_setup: returns 0 for pnpm-lock.yaml"
+assert_file_exists "$TEMP_DIR/pnpm_called" "worktree_run_setup: runs pnpm install for pnpm-lock.yaml"
+pnpm_args=$(cat "$TEMP_DIR/pnpm_called" 2>/dev/null)
+assert_contains "$pnpm_args" "frozen-lockfile" "worktree_run_setup: pnpm uses --frozen-lockfile"
+export PATH="$_saved_PATH"
+teardown_temp
+
+# Test: detects package-lock.json and runs npm ci when node_modules absent
+setup_temp
+touch "$TEMP_DIR/package-lock.json"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\necho "npm $*" > "%s/npm_called"\n' "$TEMP_DIR" > "$TEMP_DIR/bin/npm"
+chmod +x "$TEMP_DIR/bin/npm"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+ec=0
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || ec=$?
+assert_file_exists "$TEMP_DIR/npm_called" "worktree_run_setup: runs npm ci for package-lock.json"
+npm_args=$(cat "$TEMP_DIR/npm_called" 2>/dev/null)
+assert_contains "$npm_args" "ci" "worktree_run_setup: npm uses ci subcommand"
+export PATH="$_saved_PATH"
+teardown_temp
+
+# Test: detects yarn.lock and runs yarn install when node_modules absent
+setup_temp
+touch "$TEMP_DIR/yarn.lock"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\necho "yarn $*" > "%s/yarn_called"\n' "$TEMP_DIR" > "$TEMP_DIR/bin/yarn"
+chmod +x "$TEMP_DIR/bin/yarn"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+ec=0
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1 || ec=$?
+assert_file_exists "$TEMP_DIR/yarn_called" "worktree_run_setup: runs yarn install for yarn.lock"
+yarn_args=$(cat "$TEMP_DIR/yarn_called" 2>/dev/null)
+assert_contains "$yarn_args" "frozen-lockfile" "worktree_run_setup: yarn uses --frozen-lockfile"
+export PATH="$_saved_PATH"
+teardown_temp
+
+# Test: skips lockfile install when node_modules already present
+setup_temp
+touch "$TEMP_DIR/pnpm-lock.yaml"
+mkdir -p "$TEMP_DIR/node_modules"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\ntouch "%s/pnpm_called"\n' "$TEMP_DIR" > "$TEMP_DIR/bin/pnpm"
+chmod +x "$TEMP_DIR/bin/pnpm"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1
+assert_file_not_exists "$TEMP_DIR/pnpm_called" "worktree_run_setup: skips install when node_modules present"
+export PATH="$_saved_PATH"
+teardown_temp
+
+# Test: .genie/setup.sh takes precedence over lockfile detection
+setup_temp
+mkdir -p "$TEMP_DIR/.genie"
+printf '#!/bin/bash\ntouch "%s/setup_ran"\n' "$TEMP_DIR" > "$TEMP_DIR/.genie/setup.sh"
+chmod +x "$TEMP_DIR/.genie/setup.sh"
+touch "$TEMP_DIR/pnpm-lock.yaml"
+mkdir -p "$TEMP_DIR/bin"
+printf '#!/bin/bash\ntouch "%s/pnpm_called"\n' "$TEMP_DIR" > "$TEMP_DIR/bin/pnpm"
+chmod +x "$TEMP_DIR/bin/pnpm"
+_saved_PATH="$PATH"
+export PATH="$TEMP_DIR/bin:$PATH"
+worktree_run_setup "$TEMP_DIR" >/dev/null 2>&1
+assert_file_not_exists "$TEMP_DIR/pnpm_called" "worktree_run_setup: setup.sh takes precedence over lockfile"
+export PATH="$_saved_PATH"
 teardown_temp
 
 # ═══════════════════════════════════════════════


### PR DESCRIPTION
> **Stack: PR 2 of 3 — stacks on #12, merges after #12 is merged.**
> Merge order: #12 → **#13** → #14

## Summary

- Adds `worktree_run_setup()` called from `worktree_setup()` after a worktree is created
- **Option A**: executes `.genie/setup.sh` if present and executable — gives projects full control over setup
- **Option B** (fallback): detects missing `node_modules` + a lockfile and runs the appropriate frozen install:
  - `pnpm install --frozen-lockfile` (pnpm-lock.yaml)
  - `npm ci` (package-lock.json)
  - `yarn install --frozen-lockfile` (yarn.lock)
  - `bun install --frozen-lockfile` (bun.lock or bun.lockb)
- If `node_modules` already exists, skips entirely
- Install stderr is captured and logged on failure
- Dangling worktree path is logged when setup fails so the user knows where to clean up

Closes #7

## Test plan

- [x] `worktree_run_setup: returns 0 when nothing to do`
- [x] `worktree_run_setup: returns 0 when setup.sh succeeds`
- [x] `worktree_run_setup: executes .genie/setup.sh`
- [x] `worktree_run_setup: returns 1 when setup.sh fails`
- [x] `worktree_run_setup: non-executable setup.sh falls through to lockfile path`
- [x] `worktree_run_setup: returns 0 for pnpm-lock.yaml`
- [x] `worktree_run_setup: runs pnpm install for pnpm-lock.yaml` + `--frozen-lockfile`
- [x] `worktree_run_setup: runs npm ci for package-lock.json` + `ci subcommand`
- [x] `worktree_run_setup: runs yarn install for yarn.lock` + `--frozen-lockfile`
- [x] `worktree_run_setup: runs bun install for bun.lockb`
- [x] `worktree_run_setup: runs bun install for bun.lock`
- [x] `worktree_run_setup: skips install when node_modules present`
- [x] `worktree_run_setup: setup.sh takes precedence over lockfile`
- [x] `worktree_run_setup: surfaces install stderr on failure`
- [x] `worktree_run_setup: logs dangling worktree path on failure`

All 398 tests pass (`bash tests/test_run_pdlc.sh`). Session suite: 70 tests pass (`bash tests/test_session.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)