### PR TITLE
fix(batch): --from as strict phase override; add --min-phase floor constraint

### DIFF
--- a/scripts/genies
+++ b/scripts/genies
@@ -444,6 +444,12 @@ validate_args() {
             log_error "--min-phase ($MIN_PHASE) must precede --through ($THROUGH_PHASE)"
             exit 3
         fi
+        # --from and --min-phase are mutually exclusive: --from is a hard override,
+        # --min-phase is a floor — combining them produces undefined routing behavior
+        if [[ "$FROM_PHASE_EXPLICIT" == "true" ]]; then
+            log_error "--from and --min-phase are mutually exclusive; use one or the other"
+            exit 3
+        fi
     fi
 
     return 0
@@ -1572,7 +1578,8 @@ resolve_batch_items() {
                 }
                 BATCH_ITEMS+=("$(_batch_effective_phase "$item_phase"):$input")
             else
-                # Topic string — start from discover
+                # Topic strings always start at discover — they haven't been shaped yet,
+                # so --from and --min-phase overrides intentionally do not apply here.
                 BATCH_ITEMS+=("discover:$input")
             fi
         done

--- a/scripts/genies
+++ b/scripts/genies
@@ -235,6 +235,8 @@ sanitize_slug() {
 parse_args() {
     # Reset defaults
     FROM_PHASE="discover"
+    FROM_PHASE_EXPLICIT="false"
+    MIN_PHASE=""
     THROUGH_PHASE="done"
     INPUT=""
     USE_WORKTREE="true"
@@ -295,8 +297,9 @@ parse_args() {
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --from)              FROM_PHASE="$2"; shift 2 ;;
+            --from)              FROM_PHASE="$2"; FROM_PHASE_EXPLICIT="true"; shift 2 ;;
             --through)           THROUGH_PHASE="$2"; shift 2 ;;
+            --min-phase)         MIN_PHASE="$2"; shift 2 ;;
             --no-worktree)       USE_WORKTREE="false"; shift ;;
             --no-resume)         NO_RESUME="true"; shift ;;
             --lock)              USE_LOCK="true"; shift ;;
@@ -346,8 +349,9 @@ parse_args() {
                 echo "  genies item1.md item2.md          # specific items"
                 echo ""
                 echo "Phase range:"
-                echo "  --from <phase>          Start phase (default: discover)"
+                echo "  --from <phase>          Start phase — strict override in batch mode (default: discover)"
                 echo "  --through <phase>       End phase (default: done)"
+                echo "  --min-phase <phase>     Batch floor: never start earlier than this phase"
                 echo ""
                 echo "Batch:"
                 echo "  --parallel <N>          Run N items concurrently in worktrees"
@@ -428,6 +432,16 @@ validate_args() {
     if [[ "$from_idx" -ge 2 ]]; then
         if [[ ! "$INPUT" =~ ^docs/ ]] && [[ ! -f "$INPUT" ]]; then
             log_error "Phase '$FROM_PHASE' requires an existing backlog item path, not a topic string"
+            exit 3
+        fi
+    fi
+
+    # Validate --min-phase when set
+    if [[ -n "${MIN_PHASE:-}" ]]; then
+        local mp_idx
+        mp_idx=$(phase_index "$MIN_PHASE") || exit 3
+        if [[ $mp_idx -gt $through_idx ]]; then
+            log_error "--min-phase ($MIN_PHASE) must precede --through ($THROUGH_PHASE)"
             exit 3
         fi
     fi
@@ -1435,6 +1449,28 @@ worktree_teardown_failure() {
 # Batch Mode Functions
 # ─────────────────────────────────────────────
 
+# Apply --from / --min-phase constraints to a status-derived phase.
+# --from (FROM_PHASE_EXPLICIT=true): strict override — all items start at FROM_PHASE
+# --min-phase (MIN_PHASE non-empty): floor — item phase is max(status_phase, MIN_PHASE)
+# No flags: returns status_phase unchanged
+_batch_effective_phase() {
+    local status_phase="$1"
+    if [[ "$FROM_PHASE_EXPLICIT" == "true" ]]; then
+        echo "$FROM_PHASE"
+        return
+    fi
+    if [[ -n "$MIN_PHASE" ]]; then
+        local sp_idx mp_idx
+        sp_idx=$(phase_index "$status_phase" 2>/dev/null) || { echo "$status_phase"; return; }
+        mp_idx=$(phase_index "$MIN_PHASE" 2>/dev/null) || { echo "$status_phase"; return; }
+        if [[ $sp_idx -lt $mp_idx ]]; then
+            echo "$MIN_PHASE"
+            return
+        fi
+    fi
+    echo "$status_phase"
+}
+
 # Resolve batch items from inputs or backlog scan
 # Sets: BATCH_ITEMS array (format: "phase:input")
 resolve_batch_items() {
@@ -1480,7 +1516,7 @@ resolve_batch_items() {
                 [[ "$match" == "true" ]] || continue
             fi
 
-            BATCH_ITEMS+=("$item_phase:$file")
+            BATCH_ITEMS+=("$(_batch_effective_phase "$item_phase"):$file")
         done
 
         # Scan docs/topics/ for pending intake items
@@ -1534,7 +1570,7 @@ resolve_batch_items() {
                     log_info "Skipping $input (status: $status — not actionable)"
                     continue
                 }
-                BATCH_ITEMS+=("$item_phase:$input")
+                BATCH_ITEMS+=("$(_batch_effective_phase "$item_phase"):$input")
             else
                 # Topic string — start from discover
                 BATCH_ITEMS+=("discover:$input")

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -3981,6 +3981,162 @@ eval "$_orig_session_cleanup_item_ws"
 teardown_temp
 
 # ═══════════════════════════════════════════════
+# Category 46: --from strict override and --min-phase floor (issue #9)
+# ═══════════════════════════════════════════════
+
+echo ""
+echo "--- --from strict override / --min-phase floor ---"
+
+# Test: default FROM_PHASE_EXPLICIT is false
+parse_args "docs/backlog/P2-item.md"
+assert_eq "false" "$FROM_PHASE_EXPLICIT" "parse_args: default FROM_PHASE_EXPLICIT is false"
+
+# Test: --from sets FROM_PHASE_EXPLICIT to true
+parse_args --from deliver "docs/backlog/P2-item.md"
+assert_eq "true" "$FROM_PHASE_EXPLICIT" "parse_args: --from sets FROM_PHASE_EXPLICIT to true"
+
+# Test: default MIN_PHASE is empty
+parse_args "docs/backlog/P2-item.md"
+assert_eq "" "$MIN_PHASE" "parse_args: default MIN_PHASE is empty"
+
+# Test: --min-phase sets MIN_PHASE
+parse_args --min-phase deliver "docs/backlog/P2-item.md"
+assert_eq "deliver" "$MIN_PHASE" "parse_args: --min-phase sets MIN_PHASE"
+
+# Test: FROM_PHASE_EXPLICIT=true forces phase for shaped item (would normally be design)
+setup_temp
+mkdir -p "$TEMP_DIR/docs/backlog"
+printf '%s\n' '---' 'status: shaped' 'priority: P1' 'title: "Shaped Item"' '---' \
+    > "$TEMP_DIR/docs/backlog/P1-shaped.md"
+
+pushd "$TEMP_DIR" > /dev/null || exit
+INPUTS=()
+PRIORITIES=()
+FROM_PHASE="deliver"
+FROM_PHASE_EXPLICIT="true"
+MIN_PHASE=""
+resolve_batch_items
+popd > /dev/null || exit
+
+assert_eq "1" "${#BATCH_ITEMS[@]}" "resolve_batch_items: --from override enqueues shaped item"
+assert_contains "${BATCH_ITEMS[0]}" "deliver:" "resolve_batch_items: --from deliver overrides shaped→design to deliver"
+teardown_temp
+
+# Test: FROM_PHASE_EXPLICIT=true forces phase for designed item (would normally be deliver)
+setup_temp
+mkdir -p "$TEMP_DIR/docs/backlog"
+printf '%s\n' '---' 'status: designed' 'priority: P1' 'title: "Designed Item"' '---' \
+    > "$TEMP_DIR/docs/backlog/P1-designed.md"
+
+pushd "$TEMP_DIR" > /dev/null || exit
+INPUTS=()
+PRIORITIES=()
+FROM_PHASE="discern"
+FROM_PHASE_EXPLICIT="true"
+MIN_PHASE=""
+resolve_batch_items
+popd > /dev/null || exit
+
+assert_eq "1" "${#BATCH_ITEMS[@]}" "resolve_batch_items: --from override enqueues designed item"
+assert_contains "${BATCH_ITEMS[0]}" "discern:" "resolve_batch_items: --from discern overrides designed→deliver to discern"
+teardown_temp
+
+# Test: MIN_PHASE raises phase for item below floor (shaped→design raised to deliver)
+setup_temp
+mkdir -p "$TEMP_DIR/docs/backlog"
+printf '%s\n' '---' 'status: shaped' 'priority: P1' 'title: "Shaped Item"' '---' \
+    > "$TEMP_DIR/docs/backlog/P1-shaped.md"
+
+pushd "$TEMP_DIR" > /dev/null || exit
+INPUTS=()
+PRIORITIES=()
+FROM_PHASE="discover"
+FROM_PHASE_EXPLICIT="false"
+MIN_PHASE="deliver"
+resolve_batch_items
+popd > /dev/null || exit
+
+assert_eq "1" "${#BATCH_ITEMS[@]}" "resolve_batch_items: --min-phase enqueues item below floor"
+assert_contains "${BATCH_ITEMS[0]}" "deliver:" "resolve_batch_items: --min-phase deliver raises shaped→design to deliver"
+teardown_temp
+
+# Test: MIN_PHASE preserves phase for item at or above floor
+setup_temp
+mkdir -p "$TEMP_DIR/docs/backlog"
+printf '%s\n' '---' 'status: implemented' 'priority: P1' 'title: "Implemented Item"' '---' \
+    > "$TEMP_DIR/docs/backlog/P1-impl.md"
+
+pushd "$TEMP_DIR" > /dev/null || exit
+INPUTS=()
+PRIORITIES=()
+FROM_PHASE="discover"
+FROM_PHASE_EXPLICIT="false"
+MIN_PHASE="deliver"
+resolve_batch_items
+popd > /dev/null || exit
+
+assert_eq "1" "${#BATCH_ITEMS[@]}" "resolve_batch_items: --min-phase preserves phase at or above floor"
+assert_contains "${BATCH_ITEMS[0]}" "discern:" "resolve_batch_items: implemented→discern not lowered by --min-phase deliver"
+teardown_temp
+
+# Test: no --from, no --min-phase preserves status-based phase (regression guard)
+setup_temp
+mkdir -p "$TEMP_DIR/docs/backlog"
+printf '%s\n' '---' 'status: shaped' 'priority: P1' 'title: "Shaped Item"' '---' \
+    > "$TEMP_DIR/docs/backlog/P1-shaped.md"
+
+pushd "$TEMP_DIR" > /dev/null || exit
+INPUTS=()
+PRIORITIES=()
+FROM_PHASE="discover"
+FROM_PHASE_EXPLICIT="false"
+MIN_PHASE=""
+resolve_batch_items
+popd > /dev/null || exit
+
+assert_eq "1" "${#BATCH_ITEMS[@]}" "resolve_batch_items: no override preserves status-based phase"
+assert_contains "${BATCH_ITEMS[0]}" "design:" "resolve_batch_items: shaped→design unchanged without override"
+teardown_temp
+
+# Test: FROM_PHASE_EXPLICIT=true with explicit file input
+setup_temp
+printf '%s\n' '---' 'status: shaped' 'priority: P1' 'title: "Explicit Item"' '---' \
+    > "$TEMP_DIR/explicit-item.md"
+
+INPUTS=("$TEMP_DIR/explicit-item.md")
+PRIORITIES=()
+FROM_PHASE="deliver"
+FROM_PHASE_EXPLICIT="true"
+MIN_PHASE=""
+resolve_batch_items
+
+assert_eq "1" "${#BATCH_ITEMS[@]}" "resolve_batch_items: --from override applies to explicit file inputs"
+assert_contains "${BATCH_ITEMS[0]}" "deliver:" "resolve_batch_items: --from deliver overrides explicit shaped item"
+teardown_temp
+
+# Test: validate_args rejects invalid --min-phase
+FROM_PHASE="discover"
+FROM_PHASE_EXPLICIT="false"
+THROUGH_PHASE="done"
+MIN_PHASE="notaphase"
+INPUT="docs/backlog/P2-item.md"
+output=$(validate_args 2>&1)
+ec=$?
+assert_eq "3" "$ec" "validate_args: invalid --min-phase exits 3"
+MIN_PHASE=""
+
+# Test: validate_args rejects --min-phase after --through
+FROM_PHASE="discover"
+FROM_PHASE_EXPLICIT="false"
+THROUGH_PHASE="deliver"
+MIN_PHASE="discern"
+INPUT="docs/backlog/P2-item.md"
+output=$(validate_args 2>&1)
+ec=$?
+assert_eq "3" "$ec" "validate_args: --min-phase after --through exits 3"
+MIN_PHASE=""
+
+# ═══════════════════════════════════════════════
 # Summary
 # ═══════════════════════════════════════════════
 

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -4136,6 +4136,19 @@ ec=$?
 assert_eq "3" "$ec" "validate_args: --min-phase after --through exits 3"
 MIN_PHASE=""
 
+# Test: validate_args rejects --from and --min-phase used together
+FROM_PHASE="deliver"
+FROM_PHASE_EXPLICIT="true"
+THROUGH_PHASE="done"
+MIN_PHASE="discern"
+INPUT="docs/backlog/P2-item.md"
+output=$(validate_args 2>&1)
+ec=$?
+assert_eq "3" "$ec" "validate_args: --from and --min-phase together exits 3"
+assert_contains "$output" "mutually exclusive" "validate_args: --from + --min-phase error mentions mutually exclusive"
+MIN_PHASE=""
+FROM_PHASE_EXPLICIT="false"
+
 # ═══════════════════════════════════════════════
 # Summary
 # ═══════════════════════════════════════════════


### PR DESCRIPTION
> **Stack: PR 4 of 4 — stacks on #14, merges last.**
> Merge order: #12 → #13 → #14 → **#15**

## Summary

Fixes [#9] — `--from` was silently ignored in batch mode when an item's status mapped to an earlier phase, breaking oversight-layer routing.

**Option C** (preferred per issue discussion):
- `--from <phase>`: **strict override** — all batch items start at this phase, regardless of status-derived phase (`FROM_PHASE_EXPLICIT` tracking). Oversight agents can now issue hard routing directives that are respected.
- `--min-phase <phase>`: **floor constraint** — items never start earlier than this phase, but advance normally if status maps later. This is the old `--from` behavior, now correctly named.
- Using both together is rejected in `validate_args` with a clear error.
- Topic strings in batch mode always start at `discover` — phase overrides intentionally do not apply since topics haven't been shaped yet (documented in comment).

Single-item mode is unaffected; `--from` was already a strict override there.

## Behavior change

```bash
# Before: shaped items (→ design) ignored --from deliver, started at design anyway
# After:
genies --from deliver --through discern item-a.md item-b.md
#  item-a (shaped → design): overridden to deliver
#  item-b (designed → deliver): overridden to deliver

genies --min-phase deliver --through discern
#  item-a (shaped → design): raised to deliver  ← floor applied
#  item-b (implemented → discern): kept at discern  ← above floor

genies --from deliver --min-phase discern  # exits 3: mutually exclusive
```

## Test plan

- [x] `parse_args: default FROM_PHASE_EXPLICIT is false`
- [x] `parse_args: --from sets FROM_PHASE_EXPLICIT to true`
- [x] `parse_args: default MIN_PHASE is empty`
- [x] `parse_args: --min-phase sets MIN_PHASE`
- [x] `resolve_batch_items: --from override forces phase for shaped item`
- [x] `resolve_batch_items: --from override forces phase for designed item`
- [x] `resolve_batch_items: --min-phase raises phase for item below floor`
- [x] `resolve_batch_items: --min-phase preserves phase for item at or above floor`
- [x] `resolve_batch_items: no override preserves status-based phase (regression)`
- [x] `resolve_batch_items: --from override applies to explicit file inputs`
- [x] `validate_args: invalid --min-phase exits 3`
- [x] `validate_args: --min-phase after --through exits 3`
- [x] `validate_args: --from and --min-phase together exits 3`
- [x] `validate_args: --from + --min-phase error mentions mutually exclusive`

All 418 tests pass (398 from stack base + 20 new; `bash tests/test_run_pdlc.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)