### PR TITLE
fix(genies): local-first resolution + existing PR handling

### DIFF
--- a/scripts/genie-session
+++ b/scripts/genie-session
@@ -505,6 +505,18 @@ session_integrate_pr() {
     local remote_url
     remote_url=$(git -C "$repo_root" remote get-url origin 2>/dev/null)
     if command -v gh >/dev/null 2>&1; then
+        # If a PR already exists for this branch, treat as success.
+        # The /commit phase creates the PR; integration only needs to push
+        # any subsequent /done commits onto the existing branch.
+        local existing_pr
+        existing_pr=$(cd "$repo_root" && gh pr list --head "$branch" --base "$default_branch" \
+            --json url --jq '.[0].url' 2>/dev/null)
+        if [[ -n "$existing_pr" ]]; then
+            _gs_log "PR already exists: $existing_pr"
+            echo "$existing_pr"
+            return 0
+        fi
+
         local pr_url
         if ! pr_url=$(cd "$repo_root" && gh pr create \
             --base "$default_branch" \

--- a/scripts/genies
+++ b/scripts/genies
@@ -1368,6 +1368,9 @@ genies_status() {
         local slug
         slug=$(basename "$log_file" .log)
 
+        # Skip non-item files written by the batch runner itself
+        [[ "$slug" == claude_* || "$slug" == batch-manifest* ]] && continue
+
         # Check manifest membership
         local in_succeeded=false in_failed=false in_conflict=false
         for s in "${manifest_succeeded[@]+"${manifest_succeeded[@]}"}"; do

--- a/scripts/genies
+++ b/scripts/genies
@@ -1322,6 +1322,12 @@ genies_status() {
     local json_mode="${STATUS_JSON:-false}"
 
     if [[ -z "$log_dir" || ! -d "$log_dir" ]]; then
+        local repo_root
+        repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+        log_dir=$(ls -1dt "$repo_root"/logs/batch-* 2>/dev/null | head -1) || true
+    fi
+
+    if [[ -z "$log_dir" || ! -d "$log_dir" ]]; then
         log_error "No log directory found. Specify with --log-dir <dir> or STATUS_LOG_DIR."
         return 1
     fi

--- a/scripts/genies
+++ b/scripts/genies
@@ -9,6 +9,16 @@
 #   2  Merge conflict during PR creation
 #   3  Input validation error (bad args, missing file, lock held)
 
+# Local-first: when invoked as the global install, prefer a project-scoped version.
+# Only fires from ~/.claude/scripts/ — project installs skip this block entirely.
+_genies_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$_genies_script_dir" == "$HOME/.claude/scripts" ]]; then
+    _local_genies="$(git rev-parse --show-toplevel 2>/dev/null)/.claude/scripts/genies"
+    [[ -x "$_local_genies" ]] && exec "$_local_genies" "$@"
+    unset _local_genies
+fi
+unset _genies_script_dir
+
 # Only set strict mode when running directly (not sourced for testing)
 if [[ "${GENIES_SOURCED:-false}" != "true" ]]; then
     set -euo pipefail

--- a/tests/test_run_pdlc.sh
+++ b/tests/test_run_pdlc.sh
@@ -4150,6 +4150,58 @@ MIN_PHASE=""
 FROM_PHASE_EXPLICIT="false"
 
 # ═══════════════════════════════════════════════
+# Local-first resolution
+# ═══════════════════════════════════════════════
+
+echo ""
+echo "--- local-first genies resolution ---"
+
+# Test: global genies execs into project-scoped version when present
+FAKE_HOME=$(mktemp -d)
+FAKE_REPO=$(mktemp -d)
+mkdir -p "$FAKE_HOME/.claude/scripts"
+mkdir -p "$FAKE_REPO/.claude/scripts"
+cp "$RUN_PDLC" "$FAKE_HOME/.claude/scripts/genies"
+git -C "$FAKE_REPO" init -q
+# Local genies prints a unique marker so we can confirm it ran
+cat > "$FAKE_REPO/.claude/scripts/genies" << 'LOCAL_GENIES'
+#!/bin/bash
+echo "local-genies-ran"
+exit 0
+LOCAL_GENIES
+chmod +x "$FAKE_REPO/.claude/scripts/genies"
+
+output=$(cd "$FAKE_REPO" && HOME="$FAKE_HOME" bash "$FAKE_HOME/.claude/scripts/genies" 2>/dev/null) || true
+assert_contains "$output" "local-genies-ran" \
+    "local-first: global genies execs into project-scoped version"
+rm -rf "$FAKE_HOME" "$FAKE_REPO"
+
+# Test: global genies runs normally when no project-scoped version exists
+FAKE_HOME2=$(mktemp -d)
+FAKE_REPO2=$(mktemp -d)
+mkdir -p "$FAKE_HOME2/.claude/scripts"
+cp "$RUN_PDLC" "$FAKE_HOME2/.claude/scripts/genies"
+git -C "$FAKE_REPO2" init -q
+# No .claude/scripts/genies in repo — falls through to global (exits 3: no input)
+ec=0
+cd "$FAKE_REPO2" && HOME="$FAKE_HOME2" bash "$FAKE_HOME2/.claude/scripts/genies" 2>/dev/null || ec=$?
+assert_eq "3" "$ec" \
+    "local-first: falls back to global when no project-scoped version exists"
+rm -rf "$FAKE_HOME2" "$FAKE_REPO2"
+
+# Test: global genies runs normally when invoked outside a git repo
+FAKE_HOME3=$(mktemp -d)
+FAKE_NOGREPO=$(mktemp -d)
+mkdir -p "$FAKE_HOME3/.claude/scripts"
+cp "$RUN_PDLC" "$FAKE_HOME3/.claude/scripts/genies"
+# No git init — git rev-parse --show-toplevel will fail; shim must fall through safely
+ec=0
+cd "$FAKE_NOGREPO" && HOME="$FAKE_HOME3" bash "$FAKE_HOME3/.claude/scripts/genies" 2>/dev/null || ec=$?
+assert_eq "3" "$ec" \
+    "local-first: falls through safely when invoked outside a git repo"
+rm -rf "$FAKE_HOME3" "$FAKE_NOGREPO"
+
+# ═══════════════════════════════════════════════
 # Summary
 # ═══════════════════════════════════════════════
 

--- a/tests/test_session.sh
+++ b/tests/test_session.sh
@@ -889,6 +889,46 @@ assert_exit_code "1" "$ec" \
 teardown
 
 # ─────────────────────────────────────────────
+# Test: session_integrate_pr skips pr create when PR already exists
+# ─────────────────────────────────────────────
+echo ""
+echo "--- session_integrate_pr: existing PR ---"
+
+setup
+
+# Arrange — create session with a commit
+cd "$MAIN_REPO" && session_start "existing-pr-item" "deliver" >/dev/null 2>&1
+git -C "$TEMP_DIR/main-repo--existing-pr-item" config user.email "test@test.com"
+git -C "$TEMP_DIR/main-repo--existing-pr-item" config user.name "Test"
+echo "feature" > "$TEMP_DIR/main-repo--existing-pr-item/feature.txt"
+git -C "$TEMP_DIR/main-repo--existing-pr-item" add feature.txt
+git -C "$TEMP_DIR/main-repo--existing-pr-item" commit -m "add feature" -q
+
+# Arrange — mock gh: pr list returns existing URL, pr create must not be reached
+MOCK_BIN_EXISTING="$TEMP_DIR/mock-bin-existing"
+mkdir -p "$MOCK_BIN_EXISTING"
+cat > "$MOCK_BIN_EXISTING/gh" << 'MOCK_GH'
+#!/bin/bash
+if [[ "$1 $2" == "pr list" && "$*" == *"--head genie/existing-pr-item-deliver"* ]]; then
+    echo "https://github.com/test/repo/pull/99"; exit 0
+fi
+echo "ERROR: unexpected gh call: $*" >&2; exit 1
+MOCK_GH
+chmod +x "$MOCK_BIN_EXISTING/gh"
+
+# Act
+ec=0
+stdout=$(cd "$MAIN_REPO" && PATH="$MOCK_BIN_EXISTING:$PATH" session_integrate_pr "existing-pr-item" 2>/dev/null) || ec=$?
+
+# Assert
+assert_exit_code "0" "$ec" \
+    "session_integrate_pr: returns 0 when PR already exists"
+assert_contains "$stdout" "https://github.com/test/repo/pull/99" \
+    "session_integrate_pr: returns existing PR URL when PR already exists"
+
+teardown
+
+# ─────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────
 echo ""

--- a/tests/test_status.sh
+++ b/tests/test_status.sh
@@ -390,7 +390,7 @@ teardown_temp
 # Test: `genies status` without --log-dir and no LOG_DIR → exits 1
 setup_temp
 ec=0
-LOG_DIR="" bash "$RUN_PDLC" status 2>/dev/null || ec=$?
+LOG_DIR="" STATUS_LOG_DIR="/nonexistent/no-batch-logs" bash "$RUN_PDLC" status 2>/dev/null || ec=$?
 assert_exit_code "1" "$ec" "genies status: no log dir exits 1"
 teardown_temp
 

--- a/tests/test_status.sh
+++ b/tests/test_status.sh
@@ -395,6 +395,28 @@ assert_exit_code "1" "$ec" "genies status: no log dir exits 1"
 teardown_temp
 
 # ─────────────────────────────────────────────
+# Test: non-item log files (claude_stderr, batch-manifest) are skipped
+# ─────────────────────────────────────────────
+setup_temp
+# Write a real item log and two batch-runner artefacts that must be ignored
+printf "[INFO] done\n" > "$TEMP_DIR/P1-my-feature.log"
+printf "stderr output\n" > "$TEMP_DIR/claude_stderr.log"
+printf "stderr output\n" > "$TEMP_DIR/claude_stdout.log"
+printf "extra data\n"    > "$TEMP_DIR/batch-manifest.log"
+write_manifest "$TEMP_DIR" "P1-my-feature"
+
+ec=0
+output=$(STATUS_LOG_DIR="$TEMP_DIR" genies_status 2>/dev/null) || ec=$?
+
+# Only the real item should appear in output
+assert_contains "$output" "P1-my-feature" \
+    "genies_status: real item appears in status output"
+actual_count=$(echo "$output" | grep -cE "claude_stderr|claude_stdout|batch-manifest" || true)
+assert_eq "0" "$actual_count" \
+    "genies_status: non-item log files (claude_*, batch-manifest*) are excluded from status"
+teardown_temp
+
+# ─────────────────────────────────────────────
 # Summary
 # ─────────────────────────────────────────────
 


### PR DESCRIPTION
## How batch execution works

Understanding this context makes the bugs below make sense.

Each worker runs a full PDLC lifecycle:

```
deliver → discern → commit → done
```

- `/commit` creates the PR
- `/done` archives the backlog item (adds commits to the branch after the PR exists)

After all workers finish, the batch runner runs an **integration phase** for each succeeded item. It pushes any post-`/commit` commits (i.e. from `/done`) to the remote branch so they land in the PR, then ensures a PR exists.

---

## Bugs fixed

### 1. Integration phase fails when `/commit` already created a PR

`session_integrate_pr` called `gh pr create` unconditionally. Since `/commit` already opened the PR, `gh` returned an error — and the batch marked the item as **failed** despite an APPROVED run.

**Fix:** check for an existing open PR first. If found, return it as success. The branch push still runs first so `/done` commits are included.

### 2. Global `genies` ignores project-local install

When genie-team is installed both globally and in a project, the global binary always ran. Project-level installs (e.g. to test a PR branch) were silently ignored.

**Fix:** path-based shim at startup. If running from `~/.claude/scripts/`, check for a project-scoped `.claude/scripts/genies` and exec into it. Project copies skip this block entirely — no env guard, no recursion risk.

### 3. `genies status` required explicit `--log-dir`

Running `genies status` without `--log-dir` errored immediately, even during an active batch.

**Fix:** auto-detect the most recent `logs/batch-*/` directory in the repo root.

### 4. Side-effect files appeared as batch items in status

The status scanner picked up all `*.log` files, including `claude_stderr.log` written by the runner itself.

**Fix:** skip files matching `claude_*` and `batch-manifest*`.

---

## Test plan

- [ ] Parallel batch on items with existing open PRs → succeeded, not failed
- [ ] `/done` commits appear in the PR after integration
- [ ] `genies` from a project with a local install → uses local version
- [ ] `genies` from a dir with no local install → falls back to global
- [ ] `genies status` with no flags during active batch → auto-detects log dir
- [ ] Only item slugs in status table, not `claude_stderr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)