### PR TITLE
feat(sdk): provider-scoped installation

### DIFF
--- a/docs/decisions/ADR-008-distribution-models.md
+++ b/docs/decisions/ADR-008-distribution-models.md
@@ -1,0 +1,88 @@
+---
+adr_version: "1.0"
+type: adr
+id: ADR-008
+title: "Distribution Models and Provider Installation"
+status: accepted
+created: 2026-04-02
+deciders: [shaper, navigator]
+tags: [architecture, distribution, npm, installation, providers]
+---
+
+# ADR-008: Distribution Models and Provider Installation
+
+## Context
+
+Genie-team supports multiple AI providers (ADR-007) with provider SDKs as optional peer dependencies (P1-provider-scoped-installation). The tool needs to work across three distribution models:
+
+1. **`git clone` + `install.sh`** — developer install, repo on disk
+2. **`npm install -g genie-team`** — published package, no repo checkout
+3. **`npx genies-core`** — ephemeral, zero persistent state
+
+Each model has different constraints on where provider SDK dependencies can be installed and persisted.
+
+### The Problem
+
+`genies-core install openai` needs a persistent `node_modules/` to install into. Where that lives depends on how the tool was installed:
+
+| Model | Binary location | node_modules location | Persistent? |
+|-------|----------------|----------------------|-------------|
+| git clone + npm link | `<repo>/dist/index.js` (symlinked) | `<repo>/node_modules/` | Yes |
+| npm install -g | `<global-modules>/genie-team/dist/index.js` | `<global-modules>/genie-team/node_modules/` | Yes |
+| npx | Temporary cache | Temporary cache | No |
+
+### Alternatives Considered
+
+| Alternative | Pros | Cons | Why Not |
+|-------------|------|------|---------|
+| **A: npx limited to info commands** | Simple, no workarounds. npx users can still explore (`check`, `providers`, `--help`). Execution requires proper install. | npx users can't run `genies-core run` | **Accepted** — npx is for exploration, not autonomous AI execution |
+| **B: Default provider as regular dep** | npx works with Claude out of the box | Contradicts "no auto-install" principle; 57MB always ships | Violates P1 design decision |
+| **C: GENIES_PROVIDER_PATH env var** | npx could use a persistent provider location | Adds complexity; user must manage a directory; fragile | Over-engineering for a niche use case |
+| **D: Bundle all providers** | Everything always works | Defeats the purpose of scoped installation; 89MB always ships | Directly contradicts P1 |
+
+## Decision
+
+**Accepted.** Support models 1 and 2 fully. Model 3 (npx) is limited to informational commands.
+
+### How it works
+
+`genies-core install <provider>` resolves the genie-team package root from `__dirname` (the binary's own location → `dist/` → parent directory). This works identically for both git clone and npm global install because both have `node_modules/` as a sibling to `dist/`.
+
+```
+# git clone
+<repo>/dist/index.js   →  __dirname = <repo>/dist/  →  parent = <repo>/
+<repo>/node_modules/   ←  npm install openai here
+
+# npm -g
+<global>/genie-team/dist/index.js  →  __dirname = <global>/genie-team/dist/  →  parent = <global>/genie-team/
+<global>/genie-team/node_modules/  ←  npm install openai here
+```
+
+### npx behavior
+
+When run via npx, `genies-core run` detects that no providers are installed and shows:
+
+```
+Error: Provider 'claude' is not installed.
+Provider execution requires a persistent install:
+  npm install -g genie-team
+Then: genies-core install claude
+```
+
+Info commands work via npx: `npx genies-core --help`, `npx genies-core providers`, `npx genies-core check`.
+
+## Consequences
+
+**Positive:**
+- Single `__dirname` resolution works for both persistent install models
+- No special casing between git clone and npm global
+- npx users get a clear path to full installation
+- Info commands via npx are useful for "what is this tool?"
+
+**Negative:**
+- npx users cannot run `genies-core run` — must do a proper install first
+- Global npm install requires write access to global `node_modules/` for `genies-core install`
+- If the git clone repo is moved after `npm link`, the global binary breaks (npm link limitation, not specific to provider installation)
+
+**Deferred:**
+- If npx demand materializes, revisit option C (persistent provider path) or consider a "zero-dep mode" that uses the Anthropic/OpenAI/Google REST APIs directly without SDK packages

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,8 @@ Commands:
   uninstall           Remove genie-team installation
 
 Options:
+  --provider <name>   AI provider to install (claude|anthropic|openai|google)
+                      Required for global install. Can be specified multiple times.
   --commands          Install commands only
   --skills            Install skills only
   --rules             Install rules only
@@ -46,7 +48,8 @@ Options:
   --dry-run           Show what would be done
 
 Examples:
-  $0 global                      # Full global install (includes MCP)
+  $0 global --provider claude    # Install with Claude provider
+  $0 global --provider claude --provider openai  # Install with multiple providers
   $0 global --commands           # Commands only (for slash commands)
   $0 global --skills             # Skills only (for automatic behaviors)
   $0 global --mcp                # Install/configure MCP server only
@@ -445,9 +448,18 @@ install_genies() {
     fi
 }
 
+# Provider name → npm package mapping
+declare -A PROVIDER_PKGS=(
+    [claude]="@anthropic-ai/claude-agent-sdk"
+    [anthropic]="@anthropic-ai/sdk"
+    [openai]="openai"
+    [google]="@google/genai"
+)
+
 # Build and globally install genies-core (TypeScript SDK orchestrator)
+# Args: provider names (e.g., "claude" "openai")
 install_genies_core() {
-    local dry_run="$1"
+    local -a selected_providers=("$@")
 
     if [[ ! -f "$SCRIPT_DIR/package.json" ]]; then
         log_warn "No package.json found — skipping genies-core build"
@@ -459,17 +471,26 @@ install_genies_core() {
         return 0
     fi
 
-    if [[ "$dry_run" == "true" ]]; then
-        log_info "[DRY RUN] Would build and npm link genies-core"
-        return 0
-    fi
-
     log_info "Building genies-core (TypeScript SDK orchestrator)..."
 
+    # Install core dependencies (provider SDKs are peer deps, not auto-installed)
     (cd "$SCRIPT_DIR" && npm install --ignore-scripts 2>&1 | tail -1) || {
         log_warn "npm install failed — skipping genies-core build"
         return 0
     }
+
+    # Install selected provider SDKs
+    for provider in "${selected_providers[@]}"; do
+        local pkg="${PROVIDER_PKGS[$provider]}"
+        if [[ -z "$pkg" ]]; then
+            log_warn "Unknown provider: $provider (skipping)"
+            continue
+        fi
+        log_info "Installing provider: $provider ($pkg)"
+        (cd "$SCRIPT_DIR" && npm install "$pkg" 2>&1 | tail -1) || {
+            log_warn "Failed to install $pkg"
+        }
+    done
 
     (cd "$SCRIPT_DIR" && npm run build 2>&1) || {
         log_warn "npm run build failed — skipping genies-core build"
@@ -484,6 +505,7 @@ install_genies_core() {
 
     if command -v genies-core &>/dev/null; then
         log_success "genies-core built and linked globally ($(genies-core --version 2>/dev/null || echo 'unknown'))"
+        log_success "Providers installed: ${selected_providers[*]}"
     else
         log_warn "genies-core linked but not found on PATH — check your npm prefix"
     fi
@@ -678,6 +700,7 @@ cmd_global() {
     local skip_mcp="false"
     local install_all="true"
     local dry_run="false"
+    local -a providers=()
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -695,9 +718,21 @@ cmd_global() {
             --skip-mcp) skip_mcp="true" ;;
             --all) install_all="true" ;;
             --dry-run) dry_run="true" ;;
+            --provider) shift; providers+=("$1") ;;
         esac
         shift
     done
+
+    # Require --provider when installing scripts/genies-core
+    if [[ "$install_all" == "true" || "$install_scripts_flag" == "true" ]]; then
+        if [[ ${#providers[@]} -eq 0 ]]; then
+            log_error "Choose a provider with --provider flag."
+            log_info "Available providers: claude, anthropic, openai, google"
+            log_info "Example: $0 global --provider claude"
+            log_info "Multiple: $0 global --provider claude --provider openai"
+            return 1
+        fi
+    fi
 
     log_info "Installing Genie Team globally to $GLOBAL_CLAUDE_DIR/"
     [[ "$sync" == "true" ]] && log_info "Sync mode: will remove obsolete files"
@@ -776,7 +811,7 @@ cmd_global() {
 
     # Build and globally link genies-core (TypeScript SDK orchestrator)
     [[ "$install_all" == "true" || "$install_scripts_flag" == "true" ]] && \
-        install_genies_core
+        install_genies_core "${providers[@]}"
 
     # Hooks installation (scripts + settings merge)
     [[ "$install_all" == "true" || "$install_hooks_flag" == "true" ]] && \

--- a/package.json
+++ b/package.json
@@ -26,14 +26,22 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.76",
-    "@anthropic-ai/sdk": "^0.82.0",
-    "@google/genai": "^1.48.0",
     "commander": "^14.0.3",
     "execa": "^9.6.1",
     "glob": "^13.0.6",
     "js-yaml": "^4.1.1",
-    "openai": "^6.33.0",
     "p-limit": "^7.3.0"
+  },
+  "peerDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.76",
+    "@anthropic-ai/sdk": ">=0.80.0",
+    "openai": ">=6.0.0",
+    "@google/genai": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/claude-agent-sdk": { "optional": true },
+    "@anthropic-ai/sdk": { "optional": true },
+    "openai": { "optional": true },
+    "@google/genai": { "optional": true }
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,12 +11,9 @@ import { executeSingleItem, type ExecutionOptions, type SingleItemOptions } from
 import { runDaemonCycle, type DaemonOptions } from "./execution/daemon.js";
 import { listSessions, sessionCleanup, type FinishMode } from "./git/worktree.js";
 import { resolveAuth } from "./environment/auth.js";
-import { ClaudeAgentExecutor } from "./core/claude-agent-executor.js";
+import { PROVIDER_PACKAGES, getProviderStatuses } from "./environment/provider-status.js";
 import { LLMApiExecutor } from "./core/llm-api-executor.js";
 import { LocalToolExecutor } from "./core/tool-executor.js";
-import { OpenAILLMClient } from "./providers/openai-client.js";
-import { GoogleLLMClient } from "./providers/google-client.js";
-import { AnthropicLLMClient } from "./providers/anthropic-client.js";
 import type { PhaseExecutor } from "./core/phase-executor.js";
 
 function loadVersion(): string {
@@ -31,39 +28,75 @@ function loadVersion(): string {
   }
 }
 
-function createExecutor(provider: string): PhaseExecutor {
+
+async function createExecutor(provider: string): Promise<PhaseExecutor> {
+  if (!PROVIDER_PACKAGES[provider]) {
+    throw new InvalidArgumentError(
+      `Unknown provider "${provider}". Valid providers: ${Object.keys(PROVIDER_PACKAGES).join(", ")}`,
+    );
+  }
+
+  const tools = new LocalToolExecutor(process.cwd());
+
   switch (provider) {
-    case "claude":
-      return new ClaudeAgentExecutor();
+    case "claude": {
+      try {
+        const { ClaudeAgentExecutor } = await import("./core/claude-agent-executor.js");
+        return new ClaudeAgentExecutor();
+      } catch {
+        throw new Error(
+          `Provider 'claude' is not installed.\n` +
+          `Install with: genies-core install claude`,
+        );
+      }
+    }
     case "openai": {
       const apiKey = process.env.OPENAI_API_KEY;
       if (!apiKey) {
         throw new Error("--provider openai requires OPENAI_API_KEY environment variable");
       }
-      const client = new OpenAILLMClient(apiKey);
-      const tools = new LocalToolExecutor(process.cwd());
-      return new LLMApiExecutor(client, tools);
+      try {
+        const { OpenAILLMClient } = await import("./providers/openai-client.js");
+        return new LLMApiExecutor(new OpenAILLMClient(apiKey), tools);
+      } catch {
+        throw new Error(
+          `Provider 'openai' is not installed.\n` +
+          `Install with: genies-core install openai`,
+        );
+      }
     }
     case "google": {
       const apiKey = process.env.GEMINI_API_KEY;
       if (!apiKey) {
         throw new Error("--provider google requires GEMINI_API_KEY environment variable");
       }
-      const client = new GoogleLLMClient(apiKey);
-      const tools = new LocalToolExecutor(process.cwd());
-      return new LLMApiExecutor(client, tools);
+      try {
+        const { GoogleLLMClient } = await import("./providers/google-client.js");
+        return new LLMApiExecutor(new GoogleLLMClient(apiKey), tools);
+      } catch {
+        throw new Error(
+          `Provider 'google' is not installed.\n` +
+          `Install with: genies-core install google`,
+        );
+      }
     }
     case "anthropic": {
       const apiKey = process.env.ANTHROPIC_API_KEY;
       if (!apiKey) {
         throw new Error("--provider anthropic requires ANTHROPIC_API_KEY environment variable");
       }
-      const client = new AnthropicLLMClient(apiKey);
-      const tools = new LocalToolExecutor(process.cwd());
-      return new LLMApiExecutor(client, tools);
+      try {
+        const { AnthropicLLMClient } = await import("./providers/anthropic-client.js");
+        return new LLMApiExecutor(new AnthropicLLMClient(apiKey), tools);
+      } catch {
+        throw new Error(
+          `Provider 'anthropic' is not installed.\n` +
+          `Install with: genies-core install anthropic`,
+        );
+      }
     }
     default:
-      throw new InvalidArgumentError(`Unknown provider "${provider}". Valid providers: claude, anthropic, openai, google`);
+      throw new Error(`Unhandled provider: ${provider}`);
   }
 }
 
@@ -108,32 +141,63 @@ export function createCli(): Command {
     .command("providers")
     .description("List available AI providers and credential status")
     .action(() => {
-      const providers = [
-        { name: "claude", tier: 1, envKey: "N/A (OAuth or ANTHROPIC_API_KEY)", description: "Claude Agent SDK (full fidelity)" },
-        { name: "anthropic", tier: 2, envKey: "ANTHROPIC_API_KEY", description: "Anthropic Messages API" },
-        { name: "openai", tier: 2, envKey: "OPENAI_API_KEY", description: "OpenAI Chat Completions" },
-        { name: "google", tier: 2, envKey: "GEMINI_API_KEY", description: "Google Gemini GenerateContent" },
-      ];
+      const statuses = getProviderStatuses();
 
       console.log("Available Providers");
       console.log("─".repeat(60));
 
-      for (const p of providers) {
+      const STATUS_LABELS: Record<string, string> = {
+        ready: "ready",
+        installed_no_key: "installed, no key",
+        not_installed: "not installed",
+      };
+
+      for (const p of statuses) {
         const isDefault = p.name === config.provider ? " (default)" : "";
-        const hasKey = p.name === "claude"
-          ? true
-          : !!process.env[p.envKey];
-        const status = hasKey ? "ready" : "no key";
+        const label = STATUS_LABELS[p.status];
+        const hint = p.status === "not_installed"
+          ? `  genies-core install ${p.name}`
+          : p.status === "installed_no_key"
+            ? `  Set ${p.envKey}`
+            : "";
         console.log(
-          `  ${p.name.padEnd(12)} Tier ${p.tier}  [${status}]${isDefault}`,
+          `  ${p.name.padEnd(12)} Tier ${p.tier}  [${label}]${isDefault}`,
         );
-        console.log(`${"".padEnd(14)} ${p.description}`);
+        console.log(`${"".padEnd(14)} ${p.description}${hint}`);
       }
 
       console.log("");
       console.log(`Configured default: ${config.provider}`);
       console.log("Set with: genie-config.yaml → provider: <name>");
       console.log("Override: --provider <name>");
+    });
+
+  program
+    .command("install <provider>")
+    .description("Install a provider SDK (e.g., genies-core install openai)")
+    .action(async (provider: string) => {
+      const pkg = PROVIDER_PACKAGES[provider];
+      if (!pkg) {
+        console.error(`Unknown provider "${provider}". Valid providers: ${Object.keys(PROVIDER_PACKAGES).join(", ")}`);
+        process.exit(3);
+        return;
+      }
+
+      // Resolve genie-team repo root from this binary's location
+      const __filename = fileURLToPath(import.meta.url);
+      const repoRoot = join(dirname(__filename), "..");
+
+      console.log(`Installing ${provider} provider (${pkg})...`);
+
+      try {
+        const { execa } = await import("execa");
+        await execa("npm", ["install", pkg], { cwd: repoRoot, stdio: "inherit" });
+        console.log(`\nInstalled provider: ${provider}`);
+        console.log(`Use with: --provider ${provider}`);
+      } catch {
+        console.error(`Failed to install ${pkg}. Run manually: cd ${repoRoot} && npm install ${pkg}`);
+        process.exit(1);
+      }
     });
 
   function parsePhase(value: string): PhaseName {
@@ -228,7 +292,7 @@ export function createCli(): Command {
       .option("--from <phase>", "Starting phase", parsePhase, "discover" as PhaseName)
       .option("--through <phase>", "Ending phase", parsePhase, "done" as PhaseName),
   ).action(async (item: string, opts: RunOpts) => {
-      const executor = createExecutor(opts.provider ?? config.provider);
+      const executor = await createExecutor(opts.provider ?? config.provider);
       const options: SingleItemOptions = {
         ...parseExecutionOpts(opts),
         fromPhase: opts.from,
@@ -276,7 +340,7 @@ export function createCli(): Command {
       .option("--parallel <n>", "Concurrency limit")
       .option("--priority <level>", "Filter items by priority (e.g. P0)"),
   ).action(async (opts: DaemonOpts) => {
-      const executor = createExecutor(opts.provider ?? config.provider);
+      const executor = await createExecutor(opts.provider ?? config.provider);
       const options: DaemonOptions = {
         ...parseExecutionOpts(opts),
         throughPhase: opts.through,

--- a/src/environment/check.ts
+++ b/src/environment/check.ts
@@ -1,6 +1,7 @@
 import { execa } from "execa";
 import { detectAuth } from "./auth.js";
 import { loadGenieConfig } from "../config/genie-config.js";
+import { getProviderStatuses } from "./provider-status.js";
 
 export type CheckStatus = "pass" | "warn" | "fail";
 
@@ -91,42 +92,39 @@ export function checkAuth(): CheckResult {
   };
 }
 
-const PROVIDER_ENV_KEYS: Record<string, string> = {
-  claude: "ANTHROPIC_API_KEY",
-  anthropic: "ANTHROPIC_API_KEY",
-  openai: "OPENAI_API_KEY",
-  google: "GEMINI_API_KEY",
-};
-
 export function checkProvider(): CheckResult {
   const config = loadGenieConfig();
-  const provider = config.provider;
-  const envKey = PROVIDER_ENV_KEYS[provider];
+  const statuses = getProviderStatuses();
+  const active = statuses.find((s) => s.name === config.provider);
 
-  if (!envKey) {
+  if (!active) {
+    return {
+      name: "Provider",
+      status: "fail",
+      detail: `Unknown provider "${config.provider}" in config`,
+    };
+  }
+
+  if (!active.installed) {
+    return {
+      name: "Provider",
+      status: "fail",
+      detail: `${active.name} not installed — run: genies-core install ${active.name}`,
+    };
+  }
+
+  if (active.status === "installed_no_key") {
     return {
       name: "Provider",
       status: "warn",
-      detail: `Unknown provider "${provider}" in config`,
+      detail: `${active.name} (Tier ${active.tier}) — ${active.envKey} not set`,
     };
   }
 
-  // Claude Tier 1 can use OAuth — API key is optional
-  if (provider === "claude") {
-    return {
-      name: "Provider",
-      status: "pass",
-      detail: `claude (Tier 1 — Claude Agent SDK)`,
-    };
-  }
-
-  const hasKey = !!process.env[envKey];
   return {
     name: "Provider",
-    status: hasKey ? "pass" : "warn",
-    detail: hasKey
-      ? `${provider} (Tier 2 — ${envKey} set)`
-      : `${provider} (Tier 2 — ${envKey} not set)`,
+    status: "pass",
+    detail: `${active.name} (Tier ${active.tier} — ready)`,
   };
 }
 
@@ -168,6 +166,8 @@ export async function runChecks(): Promise<{
 }> {
   const results: CheckResult[] = [];
 
+  const config = loadGenieConfig();
+
   // Run async checks concurrently
   const [claudeCli, gitRepo, ghAuth] = await Promise.all([
     checkClaudeCli(),
@@ -175,10 +175,16 @@ export async function runChecks(): Promise<{
     checkGhAuth(),
   ]);
 
-  results.push(claudeCli, gitRepo, ghAuth);
+  // Only show Claude CLI check if using claude provider
+  if (config.provider === "claude") {
+    results.push(claudeCli);
+  }
+  results.push(gitRepo, ghAuth);
 
   // Sync checks
-  results.push(checkAuth());
+  if (config.provider === "claude") {
+    results.push(checkAuth());
+  }
   results.push(checkProvider());
   results.push(checkGenieConfig());
 

--- a/src/environment/provider-status.ts
+++ b/src/environment/provider-status.ts
@@ -1,0 +1,73 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+/** Provider SDK package names. Shared source of truth. */
+export const PROVIDER_PACKAGES: Record<string, string> = {
+  claude: "@anthropic-ai/claude-agent-sdk",
+  anthropic: "@anthropic-ai/sdk",
+  openai: "openai",
+  google: "@google/genai",
+};
+
+export type ProviderInstallStatus = "ready" | "installed_no_key" | "not_installed";
+
+export interface ProviderStatus {
+  name: string;
+  tier: 1 | 2;
+  installed: boolean;
+  hasKey: boolean;
+  status: ProviderInstallStatus;
+  envKey: string;
+  npmPackage: string;
+  description: string;
+}
+
+const PROVIDER_INFO: Array<{
+  name: string;
+  tier: 1 | 2;
+  envKey: string;
+  description: string;
+}> = [
+  { name: "claude", tier: 1, envKey: "ANTHROPIC_API_KEY", description: "Claude Agent SDK (full fidelity)" },
+  { name: "anthropic", tier: 2, envKey: "ANTHROPIC_API_KEY", description: "Anthropic Messages API" },
+  { name: "openai", tier: 2, envKey: "OPENAI_API_KEY", description: "OpenAI Chat Completions" },
+  { name: "google", tier: 2, envKey: "GEMINI_API_KEY", description: "Google Gemini GenerateContent" },
+];
+
+function isPackageInstalled(pkg: string): boolean {
+  try {
+    require.resolve(pkg);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getProviderStatuses(): ProviderStatus[] {
+  return PROVIDER_INFO.map((p) => {
+    const npmPackage = PROVIDER_PACKAGES[p.name];
+    const installed = isPackageInstalled(npmPackage);
+    // Claude can use OAuth — key is optional for Tier 1
+    const hasKey = p.name === "claude"
+      ? installed
+      : !!process.env[p.envKey];
+
+    let status: ProviderInstallStatus;
+    if (!installed) {
+      status = "not_installed";
+    } else if (!hasKey && p.name !== "claude") {
+      status = "installed_no_key";
+    } else {
+      status = "ready";
+    }
+
+    return {
+      ...p,
+      installed,
+      hasKey,
+      status,
+      npmPackage,
+    };
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { createCli } from "./cli.js";
 
 // Known TypeScript subcommands. Everything else falls back to shell.
-const HANDLED_COMMANDS = new Set(["check", "models", "providers", "run", "daemon", "session"]);
+const HANDLED_COMMANDS = new Set(["check", "models", "providers", "install", "run", "daemon", "session"]);
 // Global flags handled by genies-core directly
 const GLOBAL_FLAGS = new Set(["--version", "-V", "--help", "-h"]);
 


### PR DESCRIPTION
## Summary

- Move provider SDKs from dependencies to optional peerDependencies
- `install.sh global` requires `--provider` flag (no silent default)
- `genies-core install <provider>` for adding providers post-install
- Dynamic `import()` in createExecutor with clear missing-SDK errors
- Three-state provider status: ready / installed no key / not installed
- `genies-core check` degrades gracefully without Claude CLI
- ADR-008: distribution models (git clone, npm -g, npx)

### Consumer experience

```bash
./install.sh global --provider claude --provider openai
genies-core install google              # add later
genies-core providers                   # see what's available
genies-core run --provider openai "topic"  # switch freely
```

## Test plan
- [x] 259 unit tests passing
- [x] Clean typecheck
- [x] Build succeeds
- [ ] Live test install.sh --provider flow

Refs: docs/backlog/P1-provider-scoped-installation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)