### PR TITLE
chore: promote gemini-3-pro-image-preview to default image model

### DIFF
--- a/agents/designer.md
+++ b/agents/designer.md
@@ -188,8 +188,7 @@ visual:
 ## Image Generation
 
 ### Model Selection
-- **Default:** `mcp__imagegen__image_generate_gemini` with `model: "gemini-2.5-flash-image"`
-- **Premium:** `mcp__imagegen__image_generate_gemini` with `model: "gemini-3-pro-image-preview"` (on `--pro`)
+- **Default:** `mcp__imagegen__image_generate_gemini` with `model: "gemini-3-pro-image-preview"`
 
 ### Prompt Augmentation Template
 ```

--- a/install.sh
+++ b/install.sh
@@ -246,8 +246,8 @@ install_mcp_server() {
     [[ -n "${GOOGLE_API_KEY:-}" ]] && env_flags+=(-e "GOOGLE_API_KEY=${GOOGLE_API_KEY}")
     [[ -n "${OPENAI_API_KEY:-}" ]] && env_flags+=(-e "OPENAI_API_KEY=${OPENAI_API_KEY}")
     [[ -n "${REPLICATE_API_TOKEN:-}" ]] && env_flags+=(-e "REPLICATE_API_TOKEN=${REPLICATE_API_TOKEN}")
-    # Pin Gemini image model to stable production version
-    env_flags+=(-e "GOOGLE_IMAGE_MODEL=${GOOGLE_IMAGE_MODEL:-gemini-2.5-flash-image}")
+    # Pin Gemini image model to production version
+    env_flags+=(-e "GOOGLE_IMAGE_MODEL=${GOOGLE_IMAGE_MODEL:-gemini-3-pro-image-preview}")
 
     # Install the MCP server
     log_info "Installing MCP server '$MCP_SERVER_NAME' (scope: $scope)..."


### PR DESCRIPTION
## Summary
- Bumps install.sh \`GOOGLE_IMAGE_MODEL\` default from \`gemini-2.5-flash-image\` to \`gemini-3-pro-image-preview\`
- Collapses the Default/Premium split in \`agents/designer.md\` so Gemini 3 Pro is the single documented default
- Aligns shipped behavior with the production default already recorded in genie memory (best photorealism, text rendering, brand alignment)

## Test plan
- [ ] Fresh install via \`./install.sh --all\` registers MCP server with \`GOOGLE_IMAGE_MODEL=gemini-3-pro-image-preview\`
- [ ] \`/brand:image\` invocation succeeds against Gemini 3 Pro
- [ ] Existing users overriding \`GOOGLE_IMAGE_MODEL\` env var still take precedence (\`:-\` fallback semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)