### PR TITLE
docs(analysis): batch of March 2026 discovery and spike findings

### DIFF
--- a/docs/analysis/20260321_discover_ai_agent_memory_knowledge_management_landscape.md
+++ b/docs/analysis/20260321_discover_ai_agent_memory_knowledge_management_landscape.md
@@ -1,0 +1,311 @@
+---
+type: discover
+topic: "AI Agent Memory & Knowledge Management Landscape"
+reasoning_mode: deep
+status: complete
+created: "2026-03-21"
+---
+
+# Opportunity Snapshot: AI Agent Memory & Knowledge Management Landscape
+
+## 1. Discovery Question
+
+**Original:** Research the current landscape of memory and knowledge management solutions for AI agent systems -- structured memory frameworks, vector databases, hybrid approaches, sync mechanisms, and memory taxonomies.
+
+**Reframed:** What are the proven, production-ready approaches for giving AI agents persistent, retrievable memory -- and what are the real trade-offs between file-based simplicity, vector-semantic systems, and hybrid architectures in a CLI-tool context?
+
+---
+
+## 2. Observed Behaviors / Signals
+
+### Market Consolidation (2025-2026)
+
+The AI agent memory space has exploded into a distinct product category. At least 8 dedicated memory frameworks now compete, up from essentially zero in early 2024. Key players have raised significant funding:
+- **Mem0**: $24M Series A (October 2025, YC-backed). 186M API calls/quarter by Q3 2025.
+- **Zep**: Pivoted from open-source to cloud-first with Graphiti (temporal knowledge graphs) as the open-source component.
+- **Letta**: Full agent runtime with self-editing memory, #1 on Terminal-Bench (model-agnostic).
+
+### The Filesystem Benchmark Surprise
+
+Letta's own benchmarking revealed that a simple filesystem-based agent using GPT-4o mini scored **74.0% on LoCoMo**, surpassing Mem0's graph variant at 68.5%. The explanation: LLMs have extensive pretraining on filesystem operations (grep, file search, open/close). Familiarity of interface matters as much as retrieval sophistication.
+
+### Memory Taxonomy Convergence
+
+The field has converged on a four-type taxonomy (first formalized in Princeton's CoALA framework, 2023):
+1. **Working memory** -- current conversation context (the context window itself)
+2. **Semantic memory** -- accumulated facts, user preferences, project knowledge
+3. **Episodic memory** -- past interaction logs, few-shot examples distilled from history
+4. **Procedural memory** -- system prompts, decision rules, internalized skills
+
+Every major framework (Mem0, Letta, LangMem, CrewAI) builds on this taxonomy. Alternative functional taxonomies exist (factual vs experiential vs working) but have less adoption.
+
+### Hybrid Architecture as Default
+
+Pure vector search is no longer state-of-the-art. The trend is toward hybrid retrieval combining:
+- **Semantic similarity** (vector search)
+- **Keyword/BM25** (exact match)
+- **Graph traversal** (relationship navigation)
+- **Temporal filtering** (validity windows, recency weighting)
+
+Zep/Graphiti and Mem0's graph variant both implement this pattern. Benchmark evidence (Amazon/Lettria) shows hybrid GraphRAG boosts answer correctness from ~50% to 80%+ over vector-only retrieval.
+
+---
+
+## 3. Pain Points / Friction Areas
+
+### A. Genie-Team's Current Memory System
+
+Genie-team uses Claude Code's built-in file-based memory:
+- `CLAUDE.md` files for project instructions (manually written)
+- `MEMORY.md` auto-memory in `~/.claude/projects/` (agent-written)
+- `.claude/agent-memory/{genie}/` directories with typed markdown files (user, feedback, project, reference)
+- Git-tracked document trail in `docs/` for project knowledge
+- Agent memory is gitignored (per-machine, per-genie)
+
+**Current friction points:**
+1. **200-line MEMORY.md cap** -- forces aggressive pruning; lossy compression of knowledge
+2. **No semantic retrieval** -- memory lookup is linear scan of index file; relevance depends entirely on description quality
+3. **No cross-genie memory sharing** -- each genie has isolated memory; Scout cannot access what Crafter learned
+4. **No decay/relevance scoring** -- stale memories persist until manually pruned
+5. **Sync is manual** -- memory is gitignored, so multi-machine setups lose agent learning
+6. **No structured query** -- cannot ask "what did we learn about authentication?" without reading all files
+
+### B. Framework-Level Friction
+
+- **Letta requires full runtime adoption** -- cannot "plug in" as a memory layer; replaces your agent loop
+- **Mem0 graph features paywalled** -- free tier is vector-only; graph memory requires $249/mo Pro
+- **LangMem has severe framework lock-in** -- deep LangGraph coupling, Python-only
+- **AutoGen memory is effectively deprecated** -- Microsoft shifting to Agent Framework (Azure-dependent)
+- **CrewAI's unified Memory API** -- elegant but tied to CrewAI's agent model; uses ChromaDB for short-term, SQLite for long-term
+
+### C. Vector Database Operational Burden
+
+- **ChromaDB/Qdrant/Weaviate** require server processes or Docker containers -- friction for CLI tools
+- **Embedding computation** requires either API calls (cost, latency) or local models (setup, resources)
+- **sqlite-vec and LanceDB** are the only truly zero-infrastructure options
+
+---
+
+## 4. JTBD / User Moments
+
+**Primary Job:** "When working across multiple sessions on a complex project, a genie wants to recall relevant past findings and decisions so it can avoid redundant work and build on prior knowledge."
+
+**Secondary Jobs:**
+
+- "When a Scout discovers something relevant to Crafter's upcoming work, the team wants that knowledge to transfer automatically so the Crafter doesn't have to re-discover it."
+
+- "When switching between machines or sharing a project, a developer wants genie memory to follow the project so genies don't lose their accumulated learning."
+
+- "When memory grows large, a genie wants irrelevant memories to fade and relevant ones to surface so it can stay within context limits without losing important knowledge."
+
+- "When debugging a recurring issue, a genie wants to recall how similar problems were solved before so it can apply proven approaches rather than re-investigating."
+
+---
+
+## 5. Assumptions & Evidence
+
+### Evidence Analysis
+
+| Assumption | Type | Confidence | Evidence For | Evidence Against |
+|------------|------|------------|--------------|------------------|
+| File-based memory is sufficient for current scale | Feasibility | High | Letta benchmark: filesystem agent scored 74.0% on LoCoMo, beating Mem0 graph (68.5%). Claude Code's system works in production. Genie-team operates successfully with it today. | Only tested on LoCoMo (conversation retrieval). Does not test cross-session knowledge accumulation over months. No benchmark for structured project knowledge retrieval. |
+| Semantic (vector) retrieval would improve memory quality | Value | Medium | Industry convergence toward vector + hybrid search. CrewAI, Mem0, Zep all use it. 26% accuracy improvement claimed by Mem0 on LOCOMO vs full-context. | Letta's filesystem benchmark contradicts this for simple retrieval. Embedding computation adds latency/cost. The 26% claim compares against OpenAI's memory, not filesystem approach. |
+| Cross-genie memory sharing would reduce redundant work | Value | Low | Intuitive appeal. No direct evidence. Current genie isolation causes observable duplication (Scout re-discovers what previous Scout found). | Genies share the document trail (`docs/`), which may be sufficient. Memory sharing adds complexity. Risk of memory contamination between roles. |
+| Memory decay/relevance scoring is needed | Usability | Low | Academic consensus (CoALA, MAGMA). Common pattern in Mem0 and Zep. 200-line cap forces manual pruning today. | Current manual pruning works. Project lifespans may be short enough that decay is unnecessary. Over-engineering risk for a prompt-engineering project. |
+| Local-first vector DB is viable without infrastructure | Feasibility | High | sqlite-vec (runs in any SQLite), LanceDB (serverless, Rust), ChromaDB (embedded mode), Qdrant (in-memory mode). All proven in production. | Embedding generation still requires either API calls or local model. sqlite-vec is pure C with no dependencies. LanceDB requires Rust runtime. |
+| Turso/libSQL could enable cross-machine memory sync | Feasibility | Medium | Turso has native vector search + edge replication. libSQL is production-ready SQLite fork. Embedded replicas sync automatically. | Introduces cloud dependency (Turso). CRDTs would be more appropriate for conflict-free sync but add complexity. Git-based sync (current) is simpler, if manual. |
+| Knowledge graphs add meaningful value over flat vector search | Value | Medium | Zep/Graphiti: temporal knowledge graphs with validity windows. Amazon/Lettria benchmarks: hybrid GraphRAG boosts correctness from ~50% to 80%+. Mem0 graph: relationship modeling across sessions. | Requires Neo4j or similar (heavy infrastructure). Graphiti needs Neo4j backend. Letta benchmark suggests familiarity of interface matters more than retrieval sophistication. The 50%->80% improvement was on enterprise RAG, not agent memory specifically. |
+| Claude Code's memory system will improve natively | Viability | Medium | Anthropic is actively developing Claude Code. Memory system already progressed from simple CLAUDE.md to typed memory files with auto-memory. Claude platform now has a formal Memory Tool API. | No public roadmap for specific improvements. Current 200-line cap suggests Anthropic may keep memory lightweight by design. Improvements may not align with genie-team's needs. |
+
+### Confidence Grade Justifications
+
+- **File-based sufficiency (High):** Letta's benchmark is published, reproducible, and directly relevant. Claude Code's system is battle-tested across thousands of projects. Two independent data points (benchmark + production usage) with consistent signal.
+
+- **Vector retrieval improvement (Medium):** Multiple frameworks converge on vector search, but the Letta benchmark provides credible counter-evidence. Mem0's 26% claim is single-source (their own paper, arxiv 2504.19413) against a specific baseline. Industry adoption could reflect hype rather than proven value.
+
+- **Cross-genie sharing (Low):** Pure intuition. No benchmarks, no user studies, no case reports on agent knowledge isolation costs. The document trail may already solve this adequately.
+
+- **Decay/relevance (Low):** Academic papers describe the pattern. No evidence that it matters at genie-team's current scale (dozens of memories, not thousands).
+
+---
+
+## 6. Technical Signals
+
+### Feasibility Assessment: **Moderate**
+
+The technical landscape offers viable options at every complexity level:
+
+**Tier 1 -- Zero Infrastructure (current approach + improvements):**
+- Enhance file-based memory with better indexing, tagging, and search
+- Add simple relevance metadata (last_accessed, access_count) to frontmatter
+- Cross-genie read access to shared memory directory
+- Cost: Zero. Complexity: Low.
+
+**Tier 2 -- Embedded Vector Search (local-first):**
+- sqlite-vec: SQLite extension, pure C, runs anywhere SQLite runs. No server.
+- LanceDB: Serverless, Rust-based, disk-backed. "SQLite for vectors."
+- ChromaDB embedded: Python in-process mode. Good API, but Python-only.
+- Cost: Embedding API calls (~$0.0001/1K tokens with text-embedding-3-small). Complexity: Moderate.
+
+**Tier 3 -- Hybrid (vectors + structured metadata):**
+- Turso/libSQL: SQLite fork with native vector search + edge replication + SQL metadata
+- pgvector: PostgreSQL extension, 471 QPS at 99% recall on 50M vectors (but needs PostgreSQL server)
+- sqlite-vec + manual knowledge graph in SQLite tables
+- Cost: Turso free tier (500 DBs, 9GB storage). Complexity: Moderate-High.
+
+**Tier 4 -- Full Memory Platform:**
+- Mem0: Framework-agnostic, managed service, graph memory at Pro tier
+- Zep/Graphiti: Temporal knowledge graphs, requires Neo4j
+- Cost: $19-249/mo (Mem0), cloud-dependent. Complexity: High.
+
+### Constraints
+- Genie-team is a **prompt-engineering project** -- primary artifacts are markdown, not application code
+- Must work in **CLI context** -- no Docker, no server processes, no web UI required
+- Must support **headless/unattended operation** (claude -p)
+- TypeScript is the SDK migration target (current branch: `genie/P0-typescript-sdk-migration`)
+- Agent memory is currently **gitignored** -- intentional separation of project knowledge vs agent learning
+
+### Needs Architect Spike: **Conditional**
+
+If the decision is to move beyond Tier 1, an Architect spike would be needed to evaluate:
+- sqlite-vec vs LanceDB for the TypeScript SDK context
+- Embedding model selection (local vs API)
+- Memory schema design
+- Migration path from current file-based system
+
+---
+
+## 7. Opportunity Areas (Unshaped)
+
+### A. Memory Retrieval Quality Gap
+The current system has no semantic search -- memory retrieval depends entirely on description strings in MEMORY.md. As memory accumulates, finding relevant prior knowledge becomes harder. This is a retrieval quality problem, not a storage problem.
+
+### B. Cross-Genie Knowledge Transfer Gap
+Each genie operates in memory isolation. When Scout produces findings that Crafter needs, the only transfer mechanism is the document trail (`docs/analysis/`). Informal learning (patterns noticed, failed approaches, calibration insights) does not transfer between genies.
+
+### C. Memory Lifecycle Management Gap
+No automated decay, no relevance scoring, no staleness detection. The 200-line MEMORY.md cap forces manual pruning, which means knowledge is lost when it might still be valuable. The system cannot distinguish between "old but important" and "old and irrelevant."
+
+### D. Multi-Machine / Multi-User Memory Continuity Gap
+Agent memory is gitignored and machine-local. A developer switching machines or a team sharing a project loses all genie learning. The document trail transfers, but genie calibration (feedback memories, project context) does not.
+
+### E. Memory-Aware Context Engineering Gap
+Current memory is injected wholesale into context. No mechanism to selectively load memories based on the current task. As memory grows, context budget is consumed by potentially irrelevant memories rather than task-relevant knowledge.
+
+---
+
+## 8. Evidence Gaps
+
+### Critical Gaps
+
+1. **No benchmark data for genie-team's actual retrieval patterns.** The Letta filesystem benchmark and Mem0's LOCOMO scores test conversation retrieval. Genie-team's memory is project knowledge (specs, decisions, calibrations). No benchmark tests this use case.
+
+2. **Unknown memory volume trajectory.** How fast does genie memory grow? At current pace, will the 200-line cap become a serious bottleneck in 3 months? 6 months? Is there an inflection point where file-based search breaks down?
+
+3. **No measurement of knowledge loss from pruning.** When MEMORY.md is pruned, does useful knowledge get discarded? How often do genies re-discover something that was previously known but pruned?
+
+4. **Cost/benefit of embedding generation for a CLI tool.** What is the latency and dollar cost of generating embeddings for each memory write? Is it acceptable for interactive use?
+
+5. **Claude Code native memory roadmap.** Will Anthropic improve the built-in memory system in ways that make custom solutions redundant? The formal Memory Tool API suggests investment, but direction is unclear.
+
+### Secondary Gaps
+
+6. **Cross-genie contamination risk.** If genies share memory, does it blur role boundaries? Does a Critic genie benefit or suffer from having Crafter's implementation memories?
+
+7. **Turso/libSQL maturity for this use case.** Edge replication is proven for web apps. Is it appropriate for CLI tool agent memory? What is the offline experience?
+
+8. **Real-world performance of sqlite-vec at memory scale.** Benchmarks exist for millions of vectors. What about hundreds to low thousands (genie-team's likely scale)? Is the overhead justified?
+
+---
+
+## 9. Detailed Framework Comparison
+
+### Agent Memory Frameworks
+
+| Framework | Architecture | Local-First | Lock-in | Maturity | CLI-Friendly | Best For |
+|-----------|-------------|-------------|---------|----------|-------------|----------|
+| **Claude Code built-in** | File-based markdown, MEMORY.md index | Yes | Claude Code only | Production | Excellent | Current genie-team setup |
+| **Mem0** | Vector + graph dual-store, managed service | Partial (OSS core) | Low (framework-agnostic) | Production ($24M raised) | Moderate (Python SDK) | Framework-agnostic memory layer |
+| **Letta** | Three-tier self-editing memory (core/recall/archival) | Yes (self-hosted) | High (full runtime) | Production | Poor (replaces agent loop) | Agents that manage own memory |
+| **Zep/Graphiti** | Temporal knowledge graph + vector | Partial (Graphiti OSS, needs Neo4j) | Medium | Production (SOC2) | Poor (needs Neo4j) | Temporal entity tracking |
+| **LangMem** | Flat key-value + vector, LangGraph-native | Yes | High (LangGraph) | Stable (MIT) | Poor (Python, LangGraph) | LangGraph ecosystem |
+| **CrewAI Memory** | Unified API, ChromaDB + SQLite backend | Yes | High (CrewAI) | Stable | Poor (CrewAI runtime) | CrewAI agents |
+| **Hindsight** | Multi-strategy retrieval, PostgreSQL-backed | Yes (self-hosted) | Low | Early (4K stars) | Moderate | Institutional knowledge |
+| **SuperMemory** | Memory graph + RAG, managed service | No (cloud-only) | Medium | Early | Poor (cloud API) | Quick memory + RAG setup |
+
+### Vector Databases (Local-First Focus)
+
+| Database | Language | Server Required | Vector + SQL | Embedding Built-in | Size/Deps | CLI Suitability |
+|----------|---------|----------------|-------------|-------------------|-----------|----------------|
+| **sqlite-vec** | C (SQLite ext) | No | Yes (it IS SQLite) | No | Tiny (~200KB) | Excellent |
+| **LanceDB** | Rust + Python/TS bindings | No | Partial (Lance format) | No | Medium | Good |
+| **ChromaDB** | Python | No (embedded mode) | No | Yes (default model) | Large (Python deps) | Moderate |
+| **Qdrant** | Rust | Yes (or in-memory Python) | No | No | Large (binary) | Poor for CLI |
+| **Weaviate** | Go | Yes (Docker) | No | Yes (modules) | Large (Docker) | Poor for CLI |
+| **Pinecone** | Cloud-only | N/A (cloud) | No | No | None (API) | Poor for CLI |
+| **Turso/libSQL** | C (SQLite fork) | No (embedded) | Yes (native vector) | No | Small | Excellent |
+
+### Sync Mechanisms
+
+| Approach | Conflict Resolution | Offline Support | Infrastructure | Complexity | Status |
+|----------|-------------------|-----------------|----------------|------------|--------|
+| **Git-based** (current) | Manual merge | Full | None | Low | Working, gitignored memories don't sync |
+| **Turso embedded replicas** | Last-write-wins | Read-only offline | Turso cloud | Medium | Production-ready |
+| **CRDTs** (Automerge, Yjs) | Automatic merge | Full | None | High (implementation) | Mature libraries, no agent-memory implementations |
+| **Cloud vector DB** | Server-authoritative | No | Cloud service | Low (API) | Production but cloud-dependent |
+| **File sync** (Syncthing, rsync) | Last-write-wins | Full | Peer daemon | Low | Production, crude for structured data |
+
+---
+
+## 10. Routing Recommendation
+
+- [x] **Ready for Shaper** -- Problem understood
+- [ ] **Continue Discovery** -- More exploration needed
+- [ ] **Needs Architect Spike** -- Technical feasibility unclear (conditional -- see below)
+- [ ] **Needs Navigator Decision** -- Strategic question
+
+**Rationale:**
+
+The landscape is well-characterized. The problem space has five distinct opportunity areas (retrieval quality, cross-genie sharing, lifecycle management, multi-machine continuity, and context engineering). Each area has a range of solutions from simple (enhance file-based system) to complex (adopt Mem0/Zep/vector DB).
+
+**Key strategic question for Navigator:** Should genie-team invest in memory infrastructure at all, or wait for Claude Code's native memory system to improve? The current system works. The improvements are quality-of-life, not blocking. But the 200-line cap and lack of semantic retrieval will become more painful as projects grow.
+
+**If the decision is to invest:** Route to Shaper to define appetite and scope, then Architect spike for sqlite-vec vs LanceDB vs Turso evaluation in the TypeScript SDK context. The Tier 1 improvements (enhanced file-based system with better indexing and cross-genie read access) could be shaped immediately with no spike needed.
+
+---
+
+## Appendix: Key Benchmark Data Points
+
+| Benchmark | System | Score | Notes |
+|-----------|--------|-------|-------|
+| LoCoMo | Letta filesystem (GPT-4o mini) | 74.0% | Simple filesystem tools, no vector DB |
+| LoCoMo | Mem0 graph variant | 68.5% | Vector + knowledge graph |
+| LoCoMo | Mem0 (best, from their paper) | 26% above OpenAI memory | Different baseline than Letta comparison |
+| LongMemEval | Hindsight | 91.4% | Multi-strategy retrieval |
+| LongMemEval | SuperMemory | 81.6% | Memory graph + RAG |
+| LoCoMo | Full-context (all history in prompt) | Baseline | Higher token cost, 91% more tokens than Mem0 |
+
+## Appendix: Sources
+
+- [Best AI Agent Memory Systems in 2026: 8 Frameworks Compared](https://vectorize.io/articles/best-ai-agent-memory-systems)
+- [Mem0 vs Letta (MemGPT): AI Agent Memory Compared](https://vectorize.io/articles/mem0-vs-letta)
+- [Benchmarking AI Agent Memory: Is a Filesystem All You Need?](https://www.letta.com/blog/benchmarking-ai-agent-memory)
+- [AI Agent Memory: A Comparative Analysis of LangGraph, CrewAI, and AutoGen](https://dev.to/foxgem/ai-agent-memory-a-comparative-analysis-of-langgraph-crewai-and-autogen-31dp)
+- [Mem0: Building Production-Ready AI Agents with Scalable Long-Term Memory](https://arxiv.org/abs/2504.19413)
+- [Mem0 raises $24M (TechCrunch)](https://techcrunch.com/2025/10/28/mem0-raises-24m-from-yc-peak-xv-and-basis-set-to-build-the-memory-layer-for-ai-apps/)
+- [Zep: A Temporal Knowledge Graph Architecture for Agent Memory](https://arxiv.org/abs/2501.13956)
+- [Memory in the Age of AI Agents (Survey)](https://arxiv.org/abs/2512.13564)
+- [AI Agent Memory Types, Implementation, Best Practices 2026](https://47billion.com/blog/ai-agent-memory-types-implementation-best-practices/)
+- [How Claude remembers your project](https://code.claude.com/docs/en/memory)
+- [Claude Code Memory System: MEMORY.md and Automated Maintenance](https://ianlpaterson.com/blog/claude-code-memory-architecture/)
+- [LangMem SDK](https://langchain-ai.github.io/langmem/)
+- [CrewAI Memory Concepts](https://docs.crewai.com/en/concepts/memory)
+- [Turso brings Native Vector Search to SQLite](https://turso.tech/blog/turso-brings-native-vector-search-to-sqlite)
+- [sqlite-vec GitHub](https://github.com/asg017/sqlite-vec)
+- [LanceDB](https://lancedb.com/)
+- [Qdrant Edge](https://qdrant.tech/blog/qdrant-edge/)
+- [Graphiti (Zep open-source)](https://github.com/getzep/graphiti)
+- [PostgreSQL pgvector Guide 2026](https://www.instaclustr.com/education/vector-database/pgvector-key-features-tutorial-and-pros-and-cons-2026-guide/)
+- [GraphRAG & Knowledge Graphs for 2026](https://flur.ee/fluree-blog/graphrag-knowledge-graphs-making-your-data-ai-ready-for-2026/)
+- [Distributed SQLite: LibSQL and Turso in 2026](https://dev.to/dataformathub/distributed-sqlite-why-libsql-and-turso-are-the-new-standard-in-2026-58fk)
+- [Agent Interfaces in 2026: Filesystem vs API vs Database](https://arize.com/blog/agent-interfaces-in-2026-filesystem-vs-api-vs-database-what-actually-works/)

--- a/docs/analysis/20260330_discover_claude_cli_oauth_authentication.md
+++ b/docs/analysis/20260330_discover_claude_cli_oauth_authentication.md
@@ -1,0 +1,306 @@
+---
+type: discover
+topic: "Claude CLI OAuth Authentication for Headless/Daemon Modes"
+reasoning_mode: deep
+status: active
+created: "2026-03-30"
+---
+
+# Opportunity Snapshot: Claude CLI OAuth Authentication for Headless/Daemon Modes
+
+## 1. Discovery Question
+
+**Original:** How does Claude CLI OAuth authentication work, and can it support headless/daemon/non-interactive modes?
+
+**Reframed:** What are the authentication constraints and gaps that affect running Claude Code in unattended, daemon, or CI/CD scenarios -- and which features are locked behind OAuth vs. available with API keys?
+
+## 2. How Claude CLI OAuth Works Today
+
+### Authentication Flow
+
+When you run `claude` for the first time, it opens a browser window for OAuth login via claude.ai. If the browser cannot open (e.g., SSH), pressing `c` copies the login URL to the clipboard for manual use.
+
+**CLI auth commands:**
+- `claude auth login` -- Sign in. Flags: `--email` (pre-fill), `--sso` (force SSO), `--console` (API billing instead of subscription)
+- `claude auth logout` -- Sign out
+- `claude auth status` -- Show auth status as JSON (`--text` for human-readable). Exit code 0 = logged in, 1 = not
+- `/login` and `/logout` -- In-session equivalents
+
+### Token Storage
+
+| Platform | Location |
+|----------|----------|
+| macOS | Encrypted macOS Keychain |
+| Linux | `~/.claude/.credentials.json` (mode 0600) |
+| Windows | `~/.claude/.credentials.json` (user profile ACLs) |
+
+Override with `$CLAUDE_CONFIG_DIR` to change the base directory.
+
+Additional state in `~/.claude.json`: stores `hasCompletedOnboarding`, `oauthAccount` (UUID, email, org UUID), and `lastOnboardingVersion`.
+
+### Token Lifetime and Refresh
+
+- **OAuth access tokens:** Expire after ~10-15 minutes
+- **Refresh tokens:** Used to obtain new access tokens transparently in **interactive mode**
+- **`setup-token` tokens:** 1-year validity (long-lived, inference-only scope)
+- **Token refresh in non-interactive mode:** BROKEN. OAuth access tokens expire and are NOT refreshed when using `-p` with `--output-format json/stream-json`. This causes 401 errors after ~10-15 minutes. Filed as Issue #28827 (closed as duplicate of #12447 and #21765). No fix confirmed as shipped.
+
+### Authentication Precedence (highest to lowest)
+
+1. **Cloud provider credentials** -- `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_USE_FOUNDRY`
+2. **`ANTHROPIC_AUTH_TOKEN`** -- Bearer token for LLM gateways/proxies
+3. **`ANTHROPIC_API_KEY`** -- Direct API key from Claude Console (`sk-ant-api03-...`). In interactive mode, prompts once for approval. In `-p` mode, always used when present.
+4. **`apiKeyHelper`** script -- Dynamic/rotating credentials from a vault. Called every 5 min or on 401. Customize TTL via `CLAUDE_CODE_API_KEY_HELPER_TTL_MS`.
+5. **Subscription OAuth** -- Default for Pro/Max/Team/Enterprise users via `/login`
+
+**Critical note:** `apiKeyHelper`, `ANTHROPIC_API_KEY`, and `ANTHROPIC_AUTH_TOKEN` apply to **terminal CLI sessions only**. Claude Desktop and remote sessions use OAuth exclusively.
+
+### API Key vs OAuth: Billing Model
+
+| Prefix | Type | Billing |
+|--------|------|---------|
+| `sk-ant-oat01-...` | OAuth token (from `setup-token`) | Against Pro/Max subscription quota |
+| `sk-ant-api03-...` | API key (from Console) | Pay-per-token API billing |
+
+These are two completely separate billing systems.
+
+## 3. Headless/Non-Interactive OAuth
+
+### `claude setup-token` Command
+
+Generates a long-lived (1-year) OAuth token for use in automated environments:
+
+```bash
+# On a machine with a browser
+claude setup-token
+# Outputs: sk-ant-oat01-xxxxx...xxxxx (store securely, shown once)
+
+# On the headless machine
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-..."
+```
+
+**Limitations of `setup-token` tokens:**
+- **Inference-only scope** -- cannot establish Remote Control sessions
+- **Does not bypass onboarding** -- Must also create `~/.claude.json` with `{"hasCompletedOnboarding": true}` and `oauthAccount` data (Issue #8938, still open)
+- **Pro/Max subscription required** -- not available for Console/API-only accounts
+
+### Full Headless Setup Recipe (from community)
+
+```bash
+# 1. On machine with browser: generate token
+claude setup-token
+
+# 2. On machine with browser: extract account info
+cat ~/.claude.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(d.get('oauthAccount'), indent=2))"
+
+# 3. On headless machine: set env var
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-your-token-here"
+
+# 4. On headless machine: create ~/.claude.json
+cat > ~/.claude.json << 'EOF'
+{
+  "hasCompletedOnboarding": true,
+  "lastOnboardingVersion": "2.1.29",
+  "oauthAccount": {
+    "accountUuid": "your-uuid",
+    "emailAddress": "your@email.com",
+    "organizationUuid": "your-org-uuid"
+  }
+}
+EOF
+```
+
+### SSH Port Forwarding Workaround
+
+For interactive headless auth (no `setup-token`):
+
+```bash
+# Local machine
+ssh -L 8080:localhost:8080 user@remote-server.com
+
+# Remote machine
+claude /login
+# Open the displayed localhost URL in your local browser
+```
+
+Blocked by corporate firewalls or `AllowTcpForwarding no`.
+
+### Can `claude -p` Reuse OAuth Tokens?
+
+Yes, but with the token refresh bug caveat:
+- If authenticated interactively, subsequent `claude -p` calls use the cached OAuth credentials
+- If using `CLAUDE_CODE_OAUTH_TOKEN`, the long-lived token avoids the refresh issue
+- If using `ANTHROPIC_API_KEY`, no OAuth is involved at all
+
+### Device Code Flow / Service Accounts
+
+**No device code flow exists.** There is no `claude auth login --device-code` or similar.
+**No service account concept exists.** The closest equivalent is an API key from the Console.
+
+## 4. Features Requiring OAuth vs. API Key
+
+| Feature | OAuth (Subscription) | API Key | `setup-token` (OAuth, limited scope) | Notes |
+|---------|---------------------|---------|--------------------------------------|-------|
+| `claude -p` (batch/print mode) | Yes | Yes | Yes | Primary headless use case |
+| Interactive `claude` | Yes | Yes | Yes (with onboarding workaround) | |
+| Remote Control | **Yes (full OAuth only)** | No | **No** (inference-only scope insufficient) | Explicitly requires "full-scope login token" |
+| Auto Mode | Yes (Team plan required) | Unclear, likely yes with Team plan | Unclear | Requires Team plan + Sonnet/Opus 4.6 |
+| Channels | **Yes (claude.ai login only)** | **No** | Unclear (likely no -- inference-only) | "Console and API key authentication is not supported" |
+| Scheduled Tasks (`/loop`) | Yes | Yes | Yes | Session-scoped, inherits session auth |
+| Desktop Scheduled Tasks | Yes (OAuth via Desktop) | N/A | N/A | Desktop uses OAuth exclusively |
+| Cloud Scheduled Tasks | Yes (subscription) | Unclear | Unclear | Runs on Anthropic cloud |
+| Dispatch (Desktop) | Yes (OAuth via Desktop) | N/A | N/A | Desktop uses OAuth exclusively |
+| GitHub Actions (`claude-code-action`) | Yes | Yes | Yes (`claude_code_oauth_token` input) | Both auth methods documented |
+
+### Key Takeaway
+
+**Remote Control and Channels are OAuth-only.** Standard `claude -p` batch execution works fine with API keys. The Agent SDK officially recommends API keys and explicitly discourages OAuth tokens for third-party products.
+
+## 5. Agent SDK Authentication
+
+### Official Stance
+
+From the Agent SDK overview docs:
+
+> "Unless previously approved, Anthropic does not allow third party developers to offer claude.ai login or rate limits for their products, including agents built on the Claude Agent SDK. Please use the API key authentication methods described in this document instead."
+
+### SDK Auth Methods
+
+1. **`ANTHROPIC_API_KEY`** -- Primary recommended method
+2. **Cloud providers** -- Bedrock (`CLAUDE_CODE_USE_BEDROCK=1`), Vertex (`CLAUDE_CODE_USE_VERTEX=1`), Foundry (`CLAUDE_CODE_USE_FOUNDRY=1`)
+3. **`CLAUDE_CODE_OAUTH_TOKEN`** -- Works technically (community demo exists: `weidwonder/claude_agent_sdk_oauth_demo`), but officially discouraged for third-party apps
+
+### SDK vs CLI Auth Issue (#6536)
+
+Issue #6536 asked if the SDK could use `CLAUDE_CODE_OAUTH_TOKEN`. Response: The SDK is designed for **programmatic use** with API keys (pay-per-token). OAuth tokens are for **interactive CLI** use (subscription billing). Issue closed as NOT_PLANNED.
+
+**However:** The `claude_agent_sdk_oauth_demo` repo demonstrates that `CLAUDE_CODE_OAUTH_TOKEN` does work with the SDK in practice, even if not officially supported for third-party distribution.
+
+## 6. CI/CD Authentication
+
+### GitHub Actions (`claude-code-action`)
+
+Supports two auth methods:
+
+```yaml
+- uses: anthropics/claude-code-action@v1
+  with:
+    # Option 1: API Key
+    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    # Option 2: OAuth Token (from setup-token)
+    claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+### General CI/CD Pattern
+
+```bash
+# API Key approach (simplest)
+export ANTHROPIC_API_KEY="sk-ant-api03-..."
+claude -p "run tests and fix failures"
+
+# OAuth Token approach (uses subscription quota)
+export CLAUDE_CODE_OAUTH_TOKEN="sk-ant-oat01-..."
+echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
+claude -p "run tests and fix failures"
+```
+
+### Container/Docker Authentication
+
+The `setup-container-guide` pattern:
+1. Generate token locally with `claude setup-token`
+2. Pass as environment variable or mount credentials
+3. Ensure `~/.claude.json` has `hasCompletedOnboarding: true`
+
+## 7. Assumptions & Evidence
+
+| Assumption | Type | Confidence | Evidence For | Evidence Against |
+|------------|------|------------|--------------|------------------|
+| `setup-token` provides 1-year tokens | feasibility | high | Multiple sources confirm this. Community gist, official docs reference for GitHub Actions. Consistent across all sources. | No contradicting evidence found. |
+| OAuth token refresh is broken in `-p` mode | feasibility | high | Issue #28827 with reproduction steps, closed as dup of #12447 and #21765. Multiple reporters. Consistent symptoms. | Issue is closed -- may have been silently fixed. No confirmed fix in changelogs. |
+| `setup-token` + `hasCompletedOnboarding` is the complete headless recipe | usability | moderate | Community gist with detailed steps, Issue #8938 documents the gap. Multiple Docker users confirm. | The onboarding version number may drift, requiring updates. Account info extraction is undocumented. |
+| Remote Control requires full OAuth (not `setup-token`) | feasibility | high | Official docs explicitly state: "These tokens are limited to inference-only and cannot establish Remote Control sessions." Clear error message documented. | None. |
+| Channels require claude.ai OAuth login | feasibility | high | Official channels-reference docs: "Console and API key authentication is not supported." | None. |
+| Agent SDK officially requires API keys, not OAuth | viability | high | SDK overview explicitly says third-party developers should not use claude.ai login. Issue #6536 closed NOT_PLANNED. | Community demo shows it works technically. Anthropic may change stance. |
+| API keys work for all `claude -p` scenarios | feasibility | high | Auth precedence docs, GitHub Actions docs, multiple community confirmations. | None. |
+| No device code flow or service account exists | feasibility | high | Exhaustive search found no documentation or flags. Issue #7100 requested it, closed NOT_PLANNED. | May exist undocumented. |
+
+### Evidence Grade Justifications
+
+- **High confidence items:** Backed by official Anthropic docs (code.claude.com), multiple GitHub issues with consistent reports, and community replication. Sample: 3+ independent sources per claim.
+- **Moderate confidence items:** Community gists and single-source documentation. The `hasCompletedOnboarding` workaround is well-replicated but not officially documented by Anthropic.
+
+## 8. Technical Signals
+
+- **Feasibility:** Straightforward for API key auth in `-p` mode. Moderate complexity for OAuth in headless setups. Complex/fragile for features requiring full OAuth scope.
+- **Constraints:**
+  - Token refresh bug in non-interactive mode is a significant daemon risk
+  - `setup-token` scope limitations block Remote Control and likely Channels
+  - Two separate billing systems (subscription vs API) create confusion
+  - `hasCompletedOnboarding` hack is fragile and version-dependent
+- **Needs Architect spike:** Yes -- for genie-team daemon design, need to decide: API key (simple, pay-per-token) vs OAuth token (subscription billing, scope limitations) vs hybrid approach
+
+## 9. Opportunity Areas (Unshaped)
+
+1. **Authentication strategy for genie-team daemon mode** -- Which auth method(s) should the daemon use? API key is simplest and most reliable for `claude -p`. OAuth token (via `setup-token`) allows subscription billing but has scope limits and the refresh bug.
+
+2. **Token lifecycle management** -- `setup-token` tokens last 1 year. What happens at expiry? No auto-rotation mechanism exists. A daemon needs token health monitoring and renewal workflow.
+
+3. **Feature access tier mapping** -- Remote Control and Channels are OAuth-only. If genie-team wants to expose these capabilities, it needs full OAuth -- which means interactive setup and the refresh bug risk.
+
+4. **`apiKeyHelper` for credential rotation** -- The existing `apiKeyHelper` mechanism (called every 5min or on 401) could be leveraged for vault-based credential management in daemon scenarios. No community examples found for this pattern.
+
+5. **Agent SDK auth vs CLI auth divergence** -- The SDK officially forbids OAuth for third-party apps but the CLI supports it. Genie-team sits in a gray area (personal tooling, not third-party distribution). This distinction matters for the SDK migration.
+
+## 10. Evidence Gaps
+
+- **Is the token refresh bug (#28827/#12447/#21765) actually fixed?** Issues are closed but no changelog entry confirms a fix. Need to test empirically with a long-running `-p` session using OAuth.
+- **Does `setup-token` work with Channels?** The docs say "claude.ai login" required -- unclear if the long-lived token qualifies or if full-scope browser OAuth is needed.
+- **What happens when a `setup-token` token expires?** No documentation on expiry behavior or renewal process.
+- **Can `apiKeyHelper` be used with the Agent SDK?** The SDK docs mention `ANTHROPIC_API_KEY` but not `apiKeyHelper`.
+- **Auto Mode auth requirements:** Requires Team plan, but does it specifically require OAuth or does API key with Team plan work?
+- **Cloud Scheduled Tasks auth:** Runs on Anthropic infra -- how does it authenticate? Likely subscription OAuth but not confirmed.
+
+## 11. CLI Auth Flags Quick Reference
+
+| Flag/Command | Purpose |
+|-------------|---------|
+| `claude auth login` | Interactive browser OAuth |
+| `claude auth login --console` | Console/API billing login |
+| `claude auth login --sso` | Force SSO |
+| `claude auth login --email user@co.com` | Pre-fill email |
+| `claude auth logout` | Sign out |
+| `claude auth status` | JSON auth status (exit 0/1) |
+| `claude auth status --text` | Human-readable auth status |
+| `claude setup-token` | Generate 1-year inference-only OAuth token |
+| `/login` | In-session login |
+| `/logout` | In-session logout |
+| `/status` | In-session auth status |
+| `ANTHROPIC_API_KEY` | Env var for API key auth |
+| `ANTHROPIC_AUTH_TOKEN` | Env var for bearer token (gateway/proxy) |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Env var for `setup-token` output |
+| `CLAUDE_CODE_API_KEY_HELPER_TTL_MS` | Env var to customize `apiKeyHelper` refresh interval |
+
+**No `--auth-token` or `--oauth-token` CLI flags exist.** Auth is handled via env vars and the `auth` subcommand, not inline flags.
+
+## 12. Routing Recommendation
+
+- [x] **Ready for Shaper** -- Problem understood
+- [ ] **Needs Architect Spike** -- One targeted question: empirically test whether token refresh bug is fixed in current Claude Code version
+
+**Rationale:** The authentication landscape is now well-characterized. The primary decision for genie-team daemon mode is a strategy call (API key vs OAuth vs hybrid), which is a shaping question. One empirical test (does `-p` mode properly refresh OAuth tokens now?) would close the most important evidence gap, but the findings are sufficient to shape the auth approach for the SDK migration regardless of that answer, since API key auth is the reliable path.
+
+## Sources
+
+- [Authentication - Claude Code Docs](https://code.claude.com/docs/en/authentication)
+- [CLI Reference - Claude Code Docs](https://code.claude.com/docs/en/cli-reference)
+- [Remote Control - Claude Code Docs](https://code.claude.com/docs/en/remote-control)
+- [Channels Reference - Claude Code Docs](https://code.claude.com/docs/en/channels-reference)
+- [Scheduled Tasks - Claude Code Docs](https://code.claude.com/docs/en/scheduled-tasks)
+- [Agent SDK Overview - Claude API Docs](https://platform.claude.com/docs/en/agent-sdk/overview)
+- [claude-code-action setup.md](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md)
+- [Issue #28827: OAuth token refresh fails in non-interactive mode](https://github.com/anthropics/claude-code/issues/28827)
+- [Issue #7100: Document headless/remote authentication](https://github.com/anthropics/claude-code/issues/7100)
+- [Issue #8938: setup-token not enough to authenticate](https://github.com/anthropics/claude-code/issues/8938)
+- [Issue #6536: SDK use of CLAUDE_CODE_OAUTH_TOKEN](https://github.com/anthropics/claude-code/issues/6536)
+- [Automating Claude Code on Headless VPS (community gist)](https://gist.github.com/coenjacobs/d37adc34149d8c30034cd1f20a89cce9)
+- [claude_agent_sdk_oauth_demo](https://github.com/weidwonder/claude_agent_sdk_oauth_demo)

--- a/docs/analysis/20260330_discover_claude_code_autonomous_orchestration_features.md
+++ b/docs/analysis/20260330_discover_claude_code_autonomous_orchestration_features.md
@@ -1,0 +1,492 @@
+---
+type: discover
+topic: "Claude Code Autonomous Execution and Orchestration Features (March 2026)"
+reasoning_mode: deep
+status: active
+created: "2026-03-30"
+---
+
+# Opportunity Snapshot: Claude Code Autonomous Execution and Orchestration Features
+
+## 1. Discovery Question
+
+**Original:** Research the latest Claude Code features for headless/autonomous execution and orchestration -- Dispatch, Remote Control, Channels, /loop, Computer Use, and mobile integration.
+
+**Reframed:** What new autonomous execution and orchestration primitives has Claude Code shipped in early 2026, and how do they technically work? What do these capabilities mean for genie-team's execution model?
+
+## 2. Feature Inventory
+
+### 2.1 Remote Control
+
+**Released:** February 2026 (v2.1.51+)
+**Availability:** All plans (Pro, Max, Team, Enterprise). Team/Enterprise requires admin toggle.
+**Auth:** claude.ai OAuth only. API keys NOT supported.
+
+**What it does:** Connects claude.ai/code or the Claude mobile app (iOS/Android) to a Claude Code session running on your local machine. Start a task at your desk, pick it up from your phone.
+
+**Technical architecture:**
+- Your local Claude Code session makes **outbound HTTPS requests only** -- never opens inbound ports
+- On start, it **registers with the Anthropic API and polls for work**
+- When you connect from another device, the Anthropic server **routes messages between the web/mobile client and local session** over a streaming connection
+- All traffic over TLS through Anthropic API. Multiple **short-lived credentials**, each scoped to a single purpose and expiring independently
+- Works behind NAT, corporate firewalls, home routers -- no port forwarding or VPN needed
+- **Files and MCP servers never leave your machine** -- only chat messages and tool results flow through the encrypted bridge
+
+**Three modes of starting:**
+
+1. **Server mode:** `claude remote-control` -- dedicated server, waits for remote connections
+   - `--name "My Project"` -- custom session title
+   - `--spawn <mode>` -- `same-dir` (default) or `worktree` (git worktree per session)
+   - `--capacity <N>` -- max concurrent sessions (default 32)
+   - `--sandbox / --no-sandbox` -- filesystem/network isolation
+   - `--verbose` -- detailed logging
+2. **Interactive + Remote:** `claude --remote-control` (or `--rc`) -- normal interactive session also available remotely
+3. **From existing session:** `/remote-control` (or `/rc`) command inside a running session
+
+**Connecting from another device:**
+- Open session URL in browser
+- Scan QR code (press spacebar in server mode to toggle)
+- Find by name in claude.ai/code or Claude mobile app (green dot = online)
+
+**Persistence:** Can enable for all sessions via `/config`. Session reconnects automatically if laptop sleeps or network drops. Times out after ~10 minutes of no network.
+
+**Limitations:**
+- One remote session per interactive process (use server mode + `--spawn` for multiple)
+- Terminal must stay open (local process)
+- 10-minute network outage timeout
+
+---
+
+### 2.2 Dispatch
+
+**Released:** March 17, 2026 (research preview)
+**Availability:** Pro and Max plans only. NOT available on Team or Enterprise.
+**Requirement:** Claude Desktop app must be running on macOS.
+
+**What it does:** A persistent conversation with Claude that lives in the Cowork tab of the Desktop app. You message Dispatch a task from your phone, and it decides how to handle it. If the task is development work, Dispatch spawns a Code session in the Desktop app automatically.
+
+**How it works:**
+- Task routing is automatic: "fix the login bug" -> spawns Code session. "Research X topic" -> stays in Cowork
+- Code sessions appear in the Code tab sidebar with a **Dispatch badge**
+- Push notification sent to phone when session finishes or needs approval
+- If Computer Use is enabled, Dispatch-spawned sessions can use it too (app approvals expire after 30 minutes vs full session for regular sessions)
+- **Your computer must stay on** -- if laptop sleeps or app closes, Dispatch stops. It is remote control, not cloud computing.
+
+**Setup:** Pair Claude mobile app with Desktop app via [Dispatch help article](https://support.claude.com/en/articles/13947068).
+
+**Success rate:** Community testing indicates ~50% on complex tasks, higher on simple tasks (file search, summaries).
+
+---
+
+### 2.3 Channels
+
+**Released:** March 2026 (research preview, v2.1.80+)
+**Availability:** All plans. Team/Enterprise requires admin to enable `channelsEnabled`.
+**Auth:** claude.ai login required. Console and API key NOT supported.
+
+**What it does:** An MCP server that **pushes events into your running Claude Code session**. Claude reacts to messages while you're not at the terminal. Two-way: Claude reads the event and replies back through the same channel.
+
+**Supported platforms:** Telegram, Discord, iMessage (research preview). Custom channels can be built.
+
+**Technical architecture:**
+- Channel = MCP server plugin
+- Installed via `/plugin install <channel>@claude-plugins-official`
+- Enabled per-session with `--channels` flag: `claude --channels plugin:telegram@claude-plugins-official`
+- Being in `.mcp.json` is NOT enough -- server must also be named in `--channels`
+- Telegram: polls for messages via bot token
+- Discord: WebSocket connection via bot token
+- iMessage: reads `~/Library/Messages/chat.db` directly, sends via AppleScript (macOS only, requires Full Disk Access)
+- Requires [Bun](https://bun.sh) runtime
+
+**Security model:**
+- Sender allowlist per channel -- only paired IDs can push messages
+- Telegram/Discord: pairing code flow (message bot -> get code -> `/telegram:access pair <code>`)
+- iMessage: self-chat bypasses automatically; add others with `/imessage:access allow +15551234567`
+- Policy lockdown: `/telegram:access policy allowlist`
+- Allowlist also gates permission relay (channel senders who can approve/deny tool use)
+
+**Enterprise controls:**
+- `channelsEnabled` -- master switch (managed setting)
+- `allowedChannelPlugins` -- restrict which plugins can register (replaces Anthropic default allowlist)
+
+**Building custom channels:** Full reference at `/en/channels-reference`. Example: webhook receiver for CI failures, deploy pipelines, error trackers.
+
+**Key distinction from other features:**
+- Remote Control = you drive the session remotely
+- Channels = external events are pushed INTO the session
+- Dispatch = phone -> Desktop app session spawning
+
+---
+
+### 2.4 /loop (Scheduled Tasks)
+
+**Released:** v2.1.72+ (CLI), plus Desktop and Cloud variants
+**Availability:** All plans
+
+**What it does:** Runs a prompt automatically on an interval within a session. Three tiers of scheduling exist:
+
+#### Tier 1: `/loop` (session-scoped, CLI)
+
+**Syntax:**
+```
+/loop 5m check if the deployment finished and tell me what happened
+/loop check the build every 2 hours
+/loop 20m /review-pr 1234     # can invoke other commands/skills
+```
+
+**Interval syntax:** `s` (seconds), `m` (minutes), `h` (hours), `d` (days). Seconds rounded up to nearest minute (cron granularity). Default: every 10 minutes.
+
+**Under the hood:** Claude parses interval, converts to cron expression, schedules via internal tools:
+- `CronCreate` -- schedule a task (5-field cron expression, prompt, recur flag)
+- `CronList` -- list all tasks with IDs, schedules, prompts
+- `CronDelete` -- cancel by 8-character ID
+- Max 50 tasks per session
+
+**Execution model:**
+- Fires between your turns, not during mid-response
+- Scheduler checks every second for due tasks, enqueues at low priority
+- Jitter: recurring tasks fire up to 10% of period late (capped 15 min); one-shot tasks up to 90 seconds early
+- **3-day expiry** on recurring tasks -- fires one final time then self-deletes
+- All times in local timezone
+
+**One-time reminders:** Natural language: `remind me at 3pm to push the release branch`
+
+**Limitations:**
+- Session-scoped only -- gone when you exit
+- No catch-up for missed fires
+- No persistence across restarts
+
+**Disable:** `CLAUDE_CODE_DISABLE_CRON=1` environment variable
+
+#### Tier 2: Desktop Scheduled Tasks (persistent, local)
+
+- Created from Schedule page in Desktop app or by asking Claude in a session
+- **Persistent across restarts** -- survives app close
+- Task stored at `~/.claude/scheduled-tasks/<task-name>/SKILL.md` (YAML frontmatter + prompt body)
+- Frequency options: Manual, Hourly, Daily, Weekdays, Weekly (custom via Claude)
+- Runs while desktop app is open and computer awake
+- Each task gets its own session with configurable permission mode
+- Worktree toggle available for Git isolation
+- Missed run catch-up: on wake, runs once for most recently missed time (up to 7 days back)
+- `Keep computer awake` setting in Desktop to prevent idle-sleep
+
+#### Tier 3: Cloud Scheduled Tasks (persistent, cloud)
+
+- Run on Anthropic-managed cloud infrastructure
+- Work against a fresh clone of your repo (no local file access)
+- Continue even if computer is off
+- Minimum interval: 1 hour
+- Configured via `/schedule` in CLI
+- Connectors configured per task
+
+**Comparison table (from official docs):**
+
+| Attribute | Cloud | Desktop | `/loop` |
+|-----------|-------|---------|---------|
+| Runs on | Anthropic cloud | Your machine | Your machine |
+| Requires machine on | No | Yes | Yes |
+| Requires open session | No | No | Yes |
+| Persistent across restarts | Yes | Yes | No |
+| Access to local files | No (fresh clone) | Yes | Yes |
+| MCP servers | Connectors per task | Config files + connectors | Inherits from session |
+| Minimum interval | 1 hour | 1 minute | 1 minute |
+
+---
+
+### 2.5 Computer Use (Desktop App)
+
+**Released:** March 24, 2026 (research preview)
+**Availability:** Pro and Max plans only. NOT Team or Enterprise. macOS only.
+**Requirement:** Claude Desktop app running.
+
+**What it does:** Claude opens apps, controls your screen, and works directly on your machine -- mouse, keyboard, browser, everything. Used when CLI tools, connectors, and browser extensions aren't available.
+
+**Tool hierarchy (precision-first):**
+1. Connectors (Slack, Google Calendar, etc.) -- most precise
+2. Bash commands
+3. Claude in Chrome extension
+4. Computer Use -- broadest, slowest, last resort
+
+**Permission tiers per app category (fixed, not configurable):**
+
+| Tier | What Claude can do | Applies to |
+|------|-------------------|------------|
+| View only | See in screenshots | Browsers, trading platforms |
+| Click only | Click and scroll, no typing | Terminals, IDEs |
+| Full control | Click, type, drag, keyboard shortcuts | Everything else |
+
+**Setup:**
+1. Enable in Settings > Desktop app > General > Computer use toggle
+2. Grant macOS permissions: Accessibility (click/type/scroll) + Screen Recording (see screen)
+3. Per-app approval prompts on first use (session-scoped or 30 min for Dispatch sessions)
+
+**Safety:**
+- Automatic scanning of activations for prompt injection detection
+- User can stop at any time
+- Some apps blocked by default (sensitive data)
+- Extra warning for high-reach apps (Terminal, Finder, System Settings)
+- Windows hidden while Claude works, restored when done
+
+**Limitations:** macOS only. Slower than direct integrations. "Still early -- Claude can make mistakes."
+
+---
+
+### 2.6 Auto Mode
+
+**Released:** March 24, 2026 (research preview)
+**Availability:** Team plans now, Enterprise rolling out. Requires Claude Sonnet 4.6 or Opus 4.6.
+
+**What it does:** Replaces `--dangerously-skip-permissions` with a safety-checked alternative. A separate classifier model reviews each tool call before execution.
+
+**How the classifier works:**
+- Runs on **Claude Sonnet 4.6** (even if main session uses a different model)
+- Before each tool call, classifier reviews the conversation and decides if the action matches what you asked for
+- Blocks actions that: escalate beyond task scope, target unrecognized infrastructure, appear driven by hostile content (prompt injection)
+- Safe actions proceed automatically; risky ones blocked and Claude redirected
+
+**Enable:**
+- CLI: `claude --enable-auto-mode`
+- Desktop/VS Code: Settings > Claude Code, then select from permission mode dropdown
+- Shift+Tab cycles between permission modes
+
+**Admin controls:**
+- `"disableAutoMode": "disable"` in managed settings
+- `"autoMode"` key to customize classifier trust/block rules
+
+---
+
+### 2.7 Mobile App Integration
+
+**Not a standalone feature** -- mobile integration is the connecting tissue between the above features:
+
+- **Claude iOS app** (App Store) and **Android app** (Play Store) connect to:
+  - Remote Control sessions (view and send messages)
+  - Dispatch (send tasks that spawn Desktop sessions)
+  - Channels (send messages via Telegram/Discord/iMessage that push into CLI sessions)
+- Push notifications from Dispatch when sessions complete or need approval
+- QR code scanning from terminal for quick mobile connection
+- `/mobile` command in Claude Code to display download QR codes
+
+---
+
+## 3. How Features Compare (Official Matrix)
+
+| Feature | Trigger | Claude runs on | Setup | Best for |
+|---------|---------|---------------|-------|----------|
+| **Dispatch** | Message from phone | Your machine (Desktop) | Pair mobile app with Desktop | Delegating work while away |
+| **Remote Control** | Drive from claude.ai/code or mobile | Your machine (CLI/VS Code) | `claude remote-control` | Steering in-progress work |
+| **Channels** | Push from chat app or webhook | Your machine (CLI) | Install channel plugin | Reacting to external events |
+| **Slack** | @Claude in team channel | Anthropic cloud | Install Slack app | PRs and reviews from team chat |
+| **Scheduled tasks** | Set a schedule | CLI, Desktop, or cloud | Pick a frequency | Recurring automation |
+
+## 4. JTBD / User Moments
+
+**Primary Job:** "When I step away from my workstation but have development work in progress, I want to monitor and direct Claude Code from my phone so I can keep development moving without being desk-bound."
+
+**Secondary Jobs:**
+- "When a CI failure or external event occurs, I want Claude to react automatically in my existing session so I can get immediate triage without manual intervention."
+- "When I have recurring tasks (morning PR review, dependency checks, test runs), I want Claude to run them on a schedule so I can arrive to completed work."
+- "When CLI tools can't reach a system I need, I want Claude to control my screen directly so I can automate GUI-dependent workflows."
+
+## 5. Assumptions & Evidence
+
+| Assumption | Type | Confidence | Evidence For | Evidence Against |
+|------------|------|------------|--------------|------------------|
+| Remote Control is production-ready for daily use | feasibility | high | GA on all plans, detailed docs, troubleshooting guide, auto-reconnect | 10-min network timeout, must keep terminal open |
+| Dispatch is reliable for task delegation | feasibility | low | Shipped as research preview, works for simple tasks | ~50% success on complex tasks (community testing), Pro/Max only |
+| Channels replace the need for OpenClaw-style setups | value | medium | Official Telegram/Discord/iMessage support, custom channel API | Research preview, limited to allowlisted plugins, requires Bun |
+| /loop is useful for production automation | value | medium | Three-tier scheduling (session, desktop, cloud), natural language | Session-scoped /loop has 3-day expiry, no persistence |
+| Computer Use is ready for autonomous workflows | feasibility | low | Impressive demos, prompt injection detection | macOS only, "still early", research preview, Pro/Max only |
+| Auto Mode makes --dangerously-skip-permissions obsolete | value | medium | Separate classifier model, blocks hostile actions, Sonnet 4.6 reviewer | Research preview, can still allow risky actions on ambiguous intent |
+
+### Evidence Grade Justifications
+
+- **Remote Control (high confidence):** Full official documentation with detailed architecture, troubleshooting, CLI reference. Multiple independent sources confirm the polling-based outbound-only architecture. Version requirement (v2.1.51+) is specific and verifiable. Available on all plan tiers.
+- **Dispatch (low confidence):** Only available as research preview. The ~50% complex task success rate comes from a single practitioner blog post (Mejba Ahmed), not systematic testing. Limited to Pro/Max plans suggests Anthropic is not confident enough for enterprise.
+- **Channels (medium confidence):** Full official documentation with setup guides, source code on GitHub (claude-plugins-official), clear MCP server architecture. But research preview status and Bun dependency are constraints. The VentureBeat article calling it an "OpenClaw killer" is editorializing.
+- **Computer Use (low confidence):** Anthropic's own blog post says "still early" and "Claude can make mistakes." macOS-only and Pro/Max-only. The tiered permission model is well-designed but the underlying screen control reliability is acknowledged as work-in-progress.
+
+## 6. Technical Signals
+
+- **Feasibility for genie-team adoption:** moderate to complex
+- **Constraints:**
+  - Remote Control + Channels require claude.ai OAuth (not API keys) -- this conflicts with headless `claude -p` execution model
+  - Dispatch requires Desktop app -- not compatible with CLI-only genie-team architecture
+  - Computer Use requires macOS Desktop app -- not compatible with headless execution
+  - Auto Mode requires Sonnet 4.6 or Opus 4.6 -- model-locked
+  - Channels require Bun runtime
+- **Needs Architect spike:** yes -- specifically around:
+  - Whether Remote Control server mode (`--spawn worktree --capacity N`) could replace genie-team's custom worktree management
+  - Whether Channels could serve as an intake mechanism for genie-team topics
+  - Whether Auto Mode could replace `--dangerously-skip-permissions` in autonomous runs
+  - Impact of claude.ai OAuth requirement on headless/CI execution
+
+## 7. Feature-by-Feature Comparison: Genie Team vs Claude Code Native
+
+### 7.1 Session Management & Worktrees
+
+| Capability | Genie Team (Current) | Claude Code Native |
+|------------|---------------------|-------------------|
+| Worktree creation | `sessionStart(item, phase)` in `src/git/worktree.ts` — naming convention `repo--item-slug`, branch `genie/{item}-{phase}` | Remote Control server: `--spawn worktree` — auto-creates per connection |
+| Concurrent sessions | Semaphore-based batch executor, configurable `--parallel N` | `--capacity 32` concurrent sessions in server mode |
+| Session cleanup | `sessionCleanup()` with `--force`, stale reattachment | Auto-cleanup not documented; likely manual |
+| Phase-aware branching | Branch per item per phase, one worktree per logical unit | Generic worktree per session — no phase concept |
+| Session resume | `SessionTracker` passes `resumeSessionId` across phases (scout → shaper → architect → crafter → critic) | Session persistence via remote control reconnect; no cross-phase chaining |
+
+**Verdict:** Genie Team's worktree management is **more sophisticated** — it understands phases, items, and the relationship between them. Remote Control's `--spawn worktree` is a simpler building block. **Retain custom worktree layer**, but consider using Remote Control's server mode as the underlying session host for remote access.
+
+### 7.2 Scheduling & Recurring Tasks
+
+| Capability | Genie Team (Current) | Claude Code Native |
+|------------|---------------------|-------------------|
+| Daemon mode | `genies daemon` — continuous polling, `--interval`, `--max-cycles`, `--parallel N`, SIGINT/SIGTERM | Not applicable — different model |
+| Session-scoped loops | Not native (uses Claude's `/loop`) | `/loop 5m <prompt>` — CronCreate/CronList/CronDelete internally, 3-day expiry |
+| Persistent scheduling | Not implemented — relies on external cron/CI | Desktop Scheduled Tasks — survives restarts, `~/.claude/scheduled-tasks/`, missed-run catch-up |
+| Cloud scheduling | Not implemented | Cloud Scheduled Tasks — runs on Anthropic infra, fresh repo clone, min 1hr interval |
+| Batch discovery | Auto-scans backlog for `status: shaped\|designed\|implemented` items | Not applicable — no backlog concept |
+| Review cycles | Auto-retry on `CHANGES_REQUESTED` verdict (1 cycle interactive, 3 in daemon) | Not applicable — no verdict concept |
+
+**Verdict:** Genie Team's daemon mode is **uniquely valuable** — it understands the backlog, phases, and verdict loops. Claude's scheduling tiers (session/desktop/cloud) are good for **simple recurring tasks** but have no concept of backlog-driven work. **Retain daemon/batch**, but consider:
+- **Adopt** Desktop Scheduled Tasks for simple recurring genies (nightly `/diagnose`, morning `/genie:status`)
+- **Adopt** Cloud Scheduled Tasks for CI-independent recurring work
+- **Prune** nothing — these are complementary, not overlapping
+
+### 7.3 Remote Access & Mobile
+
+| Capability | Genie Team (Current) | Claude Code Native |
+|------------|---------------------|-------------------|
+| Mobile control | None | Remote Control from Claude mobile app; Dispatch from phone |
+| Web access | None | claude.ai/code connects to Remote Control sessions |
+| Push notifications | None (silent failures in unattended mode per autonomous run lessons) | Dispatch sends push notifications on completion/approval-needed |
+| Task delegation from phone | None | Dispatch routes tasks to Code sessions automatically |
+
+**Verdict:** Genie Team has **zero remote/mobile capability**. This is a clear gap. **Adopt** Remote Control for interactive genie sessions. Dispatch is interesting but unreliable (50% complex task success) and Desktop-only — **monitor but don't adopt yet**.
+
+### 7.4 Event-Driven Intake
+
+| Capability | Genie Team (Current) | Claude Code Native |
+|------------|---------------------|-------------------|
+| External event intake | Manual topic creation in `docs/topics/`, manual `/discover` invocation | Channels — MCP servers push events into running sessions |
+| CI integration | Exit codes + `--output-format stream-json` for monitoring | Custom channel plugins could bridge CI events |
+| Chat integration | None | Telegram, Discord, iMessage channels |
+| Webhook support | None | Custom channel plugins can receive webhooks |
+
+**Verdict:** Channels represent a **new capability class** that Genie Team doesn't have. Custom channel plugins could bridge CI failures, PR comments, or Slack messages into genie sessions. **Adopt** Channels for event-driven intake, but the current topic file → `/discover` flow is more structured and should be **retained** for deliberate discovery work.
+
+### 7.5 Permission Management
+
+| Capability | Genie Team (Current) | Claude Code Native |
+|------------|---------------------|-------------------|
+| Autonomous execution | `--dangerously-skip-permissions` (required per autonomous run lessons) | Auto Mode — classifier model reviews each tool call |
+| Phase-specific tool allowlists | CLI contract defines allowed tools per phase (discover: read-only, deliver: read/write/execute) | Not applicable — no phase concept |
+| Safety model | Trust-based: skip permissions or don't | Risk-based: separate Sonnet 4.6 classifier blocks scope escalation, prompt injection |
+| Enterprise control | Not applicable | `autoMode` managed setting, customizable classifier rules |
+
+**Verdict:** Auto Mode is a **significant upgrade** over `--dangerously-skip-permissions`. The classifier approach (separate model reviews each action) is fundamentally safer than binary trust. **Adopt** Auto Mode when auth model allows, but **retain** phase-specific tool allowlists as an additional layer — they're more granular than Auto Mode's intent-matching.
+
+### 7.6 Computer Use
+
+| Capability | Genie Team (Current) | Claude Code Native |
+|------------|---------------------|-------------------|
+| GUI automation | Playwright MCP (research, per `docs/analysis/20260214_research_claude_app_interaction_capabilities.md`) | Computer Use — screen control as last resort |
+| Tool hierarchy | Not formalized | Connectors > Bash > Chrome extension > Computer Use |
+
+**Verdict:** Computer Use is **not relevant** to Genie Team's current scope. Genie Team operates on code, not GUIs. Playwright MCP covers web automation needs. **Skip** — revisit only if genies need to interact with GUI-only tools.
+
+### 7.7 Context & Session State
+
+| Capability | Genie Team (Current) | Claude Code Native |
+|------------|---------------------|-------------------|
+| Session state tracking | Zero-cost hooks (track-command.sh, track-artifacts.sh, reinject-context.sh) | None built-in — sessions are ephemeral |
+| Cross-phase context | SessionTracker with `resumeSessionId` chaining | No concept of phase chaining |
+| Context commands | `/context:load`, `/context:summary`, `/context:recall`, `/context:refresh` | No equivalent |
+| Document trail | `docs/` directory with structured artifacts per phase | No equivalent |
+
+**Verdict:** Genie Team's context management is **far ahead** of native Claude Code. The hook-based session state, phase chaining, and document trail are unique differentiators. **Retain entirely** — nothing to adopt from native here.
+
+---
+
+## 8. Strategic Assessment: Adopt / Enhance / Prune
+
+### ADOPT (native features that fill real gaps)
+
+| Feature | Priority | Blocker | Value |
+|---------|----------|---------|-------|
+| **Auto Mode** | High | claude.ai OAuth auth | Replaces `--dangerously-skip-permissions` with meaningful safety |
+| **Remote Control** | Medium | claude.ai OAuth auth | Enables mobile access to genie sessions |
+| **Desktop Scheduled Tasks** | Medium | Desktop app dependency | Simple recurring genie automation without custom daemon |
+| **Channels (custom plugins)** | Medium | Research preview, Bun dependency | Event-driven intake for CI/PR/chat events |
+| **Cloud Scheduled Tasks** | Low | Fresh clone model (no local state) | CI-independent recurring tasks |
+
+### ENHANCE (our features that become better informed by native patterns)
+
+| Genie Team Feature | Enhancement Opportunity |
+|--------------------|----------------------|
+| **Daemon mode** | Add notification hooks (could use Channels as notification sink) |
+| **Worktree management** | Could offer Remote Control server mode as an optional backend for remote-accessible worktrees |
+| **Permission model** | Layer Auto Mode classifier under phase-specific tool allowlists for defense-in-depth |
+| **Session state hooks** | Expose session state to Channels so external systems can query genie status |
+| **Preflight validation** | Add Auto Mode availability check; warn if falling back to `--dangerously-skip-permissions` |
+
+### PRUNE (features we can drop if native equivalents are adopted)
+
+| Candidate | Condition | Risk |
+|-----------|-----------|------|
+| `--dangerously-skip-permissions` usage | Auto Mode is GA + supports API key auth | Low — Auto Mode is strictly better |
+| Custom session-scoped loop wrappers (if any) | `/loop` covers the use case | None — we already delegate to Claude's `/loop` |
+
+**Assessment:** Very little to prune. Genie Team's features are mostly **complementary** to native Claude Code, not duplicative. The orchestration layer operates at a higher abstraction (backlog items, phases, verdicts, review cycles) that native features don't attempt to cover.
+
+### THE AUTH WALL
+
+**Critical finding:** Every adoption candidate is blocked by the same constraint: **claude.ai OAuth is required, API keys are not supported.** Genie Team's headless execution model (`claude -p` with `ANTHROPIC_API_KEY`) cannot use Remote Control, Channels, Auto Mode, or Dispatch.
+
+**Resolution paths:**
+1. **Migrate to OAuth:** Use `claude` CLI with OAuth login instead of API key. Works for interactive sessions but unclear for headless/CI.
+2. **Hybrid model:** Interactive sessions use OAuth (getting Remote Control + Auto Mode), headless daemon keeps API key path.
+3. **Wait for API key support:** Anthropic may extend these features to API key users. No timeline available.
+4. **Agent SDK bridge:** The SDK migration (ADR-005) wraps `claude -p` — check if the SDK can authenticate via OAuth programmatically.
+
+---
+
+## 9. Opportunity Areas (Unshaped)
+
+1. **Resolve the auth wall** — Spike on OAuth vs API key for genie-team's execution model. This unblocks everything else. Determine if `claude` CLI with OAuth can work in headless mode, or if a hybrid model (interactive=OAuth, daemon=API key) is needed.
+
+2. **Auto Mode as defense-in-depth** — Layer Auto Mode's classifier under genie-team's phase-specific tool allowlists. Two levels of safety: Auto Mode catches scope escalation/injection, phase config catches phase-inappropriate tools.
+
+3. **Remote Control for supervised genie sessions** — Run genie sessions with Remote Control enabled so the user can monitor and intervene from mobile. Not as a replacement for the orchestrator, but as an observation/override layer.
+
+4. **Channels for event-driven genie work** — Build custom channel plugins that bridge CI failures, PR comments, and deploy events into running genie sessions. This could evolve the current "pull from backlog" model into a "push events trigger discovery" model.
+
+5. **Desktop Scheduled Tasks for lightweight genie automation** — Use Desktop's persistent scheduling for simple recurring tasks (`/diagnose` nightly, `/genie:status` mornings) without needing the full daemon infrastructure.
+
+## 10. Evidence Gaps
+
+- **Auth model compatibility:** Can `claude` CLI authenticate via OAuth in headless/daemon mode? Or does OAuth require interactive browser flow? This is the single most important unknown.
+- **Auto Mode classifier accuracy:** No published false-positive/false-negative rates. How often does it block legitimate genie actions? Cost impact of running a second model per tool call?
+- **Remote Control server mode at scale:** No data on `--capacity 32` with concurrent genie sessions (memory, CPU, token costs).
+- **Channels reliability:** No delivery guarantees, latency data, or failure mode documentation for Telegram/Discord polling.
+- **Cloud Scheduled Tasks environment:** What tools are available? Can MCP servers run? What network access exists? Is the repo clone shallow or full?
+- **API key support timeline:** Will these features ever support API keys, or is OAuth the permanent direction?
+- **Enterprise availability:** Dispatch and Computer Use are Pro/Max only. No timeline for Team/Enterprise.
+- **Cost impact:** Auto Mode runs a second model call per tool invocation. Channels poll continuously. No pricing data available.
+
+## 11. Routing Recommendation
+
+- [ ] **Continue Discovery** -- More exploration needed
+- [ ] **Ready for Shaper** -- Problem understood
+- [x] **Needs Architect Spike** -- Technical feasibility unclear
+- [x] **Needs Navigator Decision** -- Strategic question
+
+**Rationale:** The discovery question is well-mapped. The path forward requires two things:
+
+1. **Architect spike on OAuth auth in headless mode** — This is the gate for all adoption. Test whether `claude` CLI can authenticate via OAuth without an interactive browser flow (e.g., device code flow, service account, or token caching). If not, determine if a hybrid auth model is viable.
+
+2. **Strategic decision on adoption sequencing** — Given that Genie Team's orchestration layer operates at a higher abstraction than native features, the question isn't "replace vs keep" but "which native primitives to compose into the existing architecture." Recommended sequencing:
+   - **Now:** Auto Mode adoption (highest safety ROI, simplest integration)
+   - **Next:** Remote Control for supervised sessions + Desktop Scheduled Tasks for lightweight automation
+   - **Later:** Channels for event-driven intake (requires custom plugin development)
+   - **Skip:** Dispatch (unreliable), Computer Use (wrong scope)
+
+**Key insight:** Genie Team's orchestration layer remains valuable even with full native feature adoption. Native features provide **infrastructure primitives** (session hosting, scheduling, event intake, permission classification). Genie Team provides **workflow semantics** (backlog-driven phases, verdict loops, context chaining, document trail). These are complementary layers, not competing ones.

--- a/docs/analysis/20260330_discover_context_engineering_improvements.md
+++ b/docs/analysis/20260330_discover_context_engineering_improvements.md
@@ -1,0 +1,171 @@
+---
+type: discover
+topic: "Context Engineering Improvements for Genie Team"
+reasoning_mode: deep
+status: active
+created: "2026-03-30"
+---
+
+# Opportunity Snapshot: Context Engineering Improvements
+
+## Discovery Question
+
+How can genie-team improve context management to (1) load more accurate context that aligns genies to the right approach, and (2) reduce the time and token cost of loading and maintaining that context?
+
+## Observed Behaviors / Signals
+
+### External Landscape (from provided articles)
+
+**Refactoring.fm — "Managing Context for AI Coding" (Luca Rossi):**
+- Core thesis: context engineering, not prompt engineering, separates high-performing AI-assisted teams from the rest. "Magical incantations don't substitute for substance."
+- Framework: 2x2 matrix — single/multi-player x static/dynamic. Teams should move toward multi-player + dynamic (shared context, automatically fetched).
+- Key insight: "What's good for humans is good for AI" — AI amplifies existing organizational knowledge hygiene.
+- Four-part agenda: distinguish tasks from procedures, share the "why" not just the "what", identify task-relevant context, keep context small.
+
+**Unblocked — "Context Engineering":**
+- Core thesis: "Prompts can shape tone and format, but they do not give models the knowledge they need to solve meaningful engineering problems."
+- 8-stage context pipeline: data ingestion → environment learning → memory management → working context identification → intent interpretation → first-pass retrieval → relationship exploration → ranking/de-conflicting/refinement.
+- Key challenges: access control, data relationships across systems, conflicting sources, token constraints, memory management, latency vs completeness.
+- Claims >98% accuracy through dynamic context pulling from docs, issue trackers, and conversations.
+
+### Internal Signals (genie-team codebase)
+
+- **7 complementary context systems** already exist: session context, CLAUDE.md/rules, agent memory, persistent specs, architecture artifacts, document trail, hook-based state.
+- **Hook-based zero-cost state tracking** — shell hooks maintain session state across context compactions with no LLM API calls.
+- **Known cost pain**: minimum-turn guard was created after ~$15 wasted on input tokens with zero useful work. Deliver phase is 50-65% of total run cost.
+- **ADR-001 trade-off**: "repeated LLM context loading for each process" explicitly listed as a negative of the thin orchestrator approach.
+- **ADR-005 mitigation**: SDK-integrated orchestrator enables "session resume across genie phases — context preservation without re-prompting."
+- **Empty context templates**: `market.md`, `season.md`, `assumptions.md` exist as scaffolding but are unpopulated — context loading reads files that add no value.
+- **Memory system is transitional**: 150-line caps, no semantic retrieval, no cross-genie sharing, no decay/relevance scoring (per 20260321 analysis).
+
+## Pain Points / Friction Areas
+
+1. **Shotgun context loading** — `/context:load` reads everything: all specs, all ADRs, all backlog items, C4 diagrams, stack profiles. Most of this is irrelevant to the current task. Every token loaded is a token paid for.
+
+2. **No task-relevance filtering** — Context is loaded by category (all specs, all ADRs), not by relevance to the task at hand. A genie working on image generation loads auth middleware ADRs.
+
+3. **Redundant re-loading across phases** — Each genie phase (discover → define → design → deliver → discern) starts fresh, re-reading the same CLAUDE.md, rules, specs, and ADRs. The thin orchestrator model (ADR-001) makes this structural.
+
+4. **Context files that add noise** — Empty template files (market.md, season.md, assumptions.md) are loaded but contribute zero signal. Rules files total ~526 lines, always loaded regardless of task.
+
+5. **Agent memory is siloed** — Each genie has its own memory. Scout's knowledge about the codebase can't inform Crafter. Architect's pattern knowledge can't guide Critic. No cross-genie learning.
+
+6. **No context cost observability** — No metrics on how many tokens each context source consumes, or which sources actually influenced the genie's output. Can't optimize what you can't measure.
+
+7. **Static context in a dynamic world** — Context is file-based and manually curated. No automatic retrieval from git history, test results, or recent changes. The "dynamic" quadrant from Rossi's framework is aspirational.
+
+8. **Spec/ADR staleness** — 90-day staleness threshold for C4 diagrams exists but specs and ADRs have no freshness mechanism. Stale context is worse than no context — it misleads.
+
+## JTBD / User Moments
+
+**When** a genie starts a new phase (discover, design, deliver...),
+**it wants to** load exactly the context needed to understand the task, constraints, and prior decisions,
+**so it can** produce accurate output without wasting tokens on irrelevant information.
+
+**When** an orchestrator runs multiple genie phases in sequence,
+**it wants to** preserve relevant context across phase boundaries,
+**so it can** avoid re-paying for the same context loading at every transition.
+
+**When** a human reviews genie output that seems misaligned,
+**they want to** understand what context the genie had (and didn't have),
+**so they can** diagnose whether the issue is missing context, stale context, or wrong interpretation.
+
+**When** context costs are high and rising with project complexity,
+**the team wants to** reduce per-task context overhead without sacrificing accuracy,
+**so they can** scale usage without proportional cost growth.
+
+## Assumptions & Evidence
+
+### High Risk (test first)
+
+| # | Assumption | Type | Evidence | Impact if Wrong |
+|---|-----------|------|----------|-----------------|
+| A1 | Task-scoped context loading (loading only relevant specs/ADRs) would significantly reduce token costs | Feasibility | Weak — no measurement of current per-source token costs | High — optimization effort wasted if context is already small |
+| A2 | Genies would produce better output with less but more relevant context | Value | Moderate — Rossi's "keep context small" principle + known hallucination patterns with large contexts | High — undermines entire optimization direction |
+| A3 | Cross-genie memory sharing would improve downstream phase quality | Value | Weak — no evidence of downstream failures caused by siloed memory | Medium — significant implementation effort for uncertain gain |
+| A4 | SDK session resume (ADR-005) will meaningfully reduce re-loading costs | Feasibility | Moderate — SDK migration is in progress, resume API exists | High — if it doesn't work, the structural re-loading problem from ADR-001 persists |
+
+### Medium Risk
+
+| # | Assumption | Type | Evidence | Impact if Wrong |
+|---|-----------|------|----------|-----------------|
+| A5 | Empty context templates add measurable noise | Usability | Moderate — templates exist, are loaded, but have no content | Low — trivial to skip empty files |
+| A6 | Context cost observability would enable meaningful optimization | Value | Moderate — can't optimize without measurement, but team may not act on data | Medium — effort to build instrumentation with uncertain follow-through |
+| A7 | Semantic/vector retrieval for agent memory would outperform file-based memory | Feasibility | Moderate — 20260321 analysis evaluated options, but no prototype tested | Medium — adds dependency complexity for uncertain gain |
+
+### Lower Risk
+
+| # | Assumption | Type | Evidence | Impact if Wrong |
+|---|-----------|------|----------|-----------------|
+| A8 | Git history and recent changes could serve as dynamic context | Value | Strong — Unblocked's pipeline model + obvious utility of "what changed recently" | Low — incremental improvement |
+| A9 | Spec/ADR staleness detection would prevent misalignment | Value | Moderate — 90-day threshold exists for C4 but not specs/ADRs | Low — easy to add, minimal downside |
+
+## Technical Signals
+
+- **SDK migration (P0-typescript-sdk-migration)** is the primary technical enabler — session resume, phase prompt construction with context injection, and `settingSources` configuration are all in-flight.
+- **Hook system** already demonstrates zero-cost context maintenance — pattern could extend to context relevance scoring.
+- **Agent memory landscape analysis** (20260321) evaluated vector DB options (sqlite-vec, LanceDB, ChromaDB) but no prototype exists.
+- **Context protocol** for external systems (Cataliva scoping) shows the team has already thought about context boundaries — topic files with frontmatter as the interface.
+
+## Opportunity Areas (Unshaped)
+
+### O1: Task-Scoped Context Loading
+Instead of loading all specs, ADRs, and context files, use the backlog item's `spec_ref`, `adr_refs`, and domain to load only relevant context. The backlog item already has this metadata — it's just not used for scoping.
+
+### O2: Context Cost Instrumentation
+Measure token cost per context source per phase. Surface in session summaries. Enable data-driven pruning of low-value context sources. Could be a hook that counts tokens per file read.
+
+### O3: Phase-to-Phase Context Handoff
+Rather than each phase re-loading from scratch, produce a structured handoff artifact that carries forward the relevant context subset. `/handoff` command exists but doesn't optimize for token efficiency.
+
+### O4: Context Relevance Scoring
+Before loading a context file, score its relevance to the current task (by keyword overlap, backlog item references, or recency). Skip files below a threshold. Start with a simple heuristic before investing in semantic retrieval.
+
+### O5: Cross-Genie Memory Index
+Create a shared memory index that genies can query without loading all other genies' full memories. A lightweight "what does Scout know about X?" lookup.
+
+### O6: Dynamic Context from Git
+Auto-generate a "recent changes relevant to this task" context snippet from git log, filtered by files/directories related to the backlog item. Zero manual curation.
+
+## Evidence Gaps
+
+1. **No token-per-source measurement** — We don't know how many tokens each context source consumes. Before optimizing, measure. Recommended experiment: instrument one `/deliver` run to log token counts per file read. (Quick — hours)
+
+2. **No A/B on context scoping** — We haven't tested whether scoped context produces better or worse genie output. Recommended experiment: run the same task twice — once with full context, once with task-scoped context — and compare output quality. (Medium — days)
+
+3. **SDK resume effectiveness unknown** — ADR-005 promises context preservation, but the SDK migration is in-progress. Recommended experiment: once Slice 13+ is complete, measure token savings from session resume vs. fresh start. (Medium — blocked on SDK progress)
+
+4. **Cross-genie memory value unproven** — No evidence that siloed memory has caused downstream failures. Recommended experiment: review critic feedback on delivered items — are rejections traceable to context that another genie had but the delivering genie lacked? (Quick — hours)
+
+## Routing Recommendation
+
+**Continue Discovery → then Ready for Shaper** on specific opportunities.
+
+The highest-leverage next step is **evidence gathering on A1 (context cost measurement)**. Without knowing where tokens are spent, optimization is guesswork.
+
+Recommended sequence:
+1. **Quick spike**: Instrument a `/deliver` run to measure token-per-source costs (validates A1, informs O1/O2)
+2. **Define O1 (Task-Scoped Context Loading)** if measurement confirms significant waste — this has the best cost/value ratio and uses metadata that already exists in backlog items
+3. **Defer O5 (Cross-Genie Memory)** until evidence of cross-genie context failures exists (validates A3)
+4. **Monitor SDK migration** for O3 (Phase-to-Phase Handoff) — ADR-005 may solve this structurally
+
+The SDK migration (P0-typescript-sdk-migration) is the tectonic shift. Many context inefficiencies are structural consequences of the thin orchestrator model (ADR-001) that the SDK-integrated orchestrator (ADR-005) is designed to address. Time context improvements to land after or alongside the SDK work.
+
+**Discovery cadence**: Revisit this opportunity tree after the token measurement spike and after SDK Slice 13+ lands. Re-run `/discover` when new evidence from experiments changes the priority ordering.
+
+## Architecture Context
+
+- **ADR-001 (Thin Orchestrator)**: Root cause of repeated context loading — each CLI process starts fresh. Accepted trade-off at the time.
+- **ADR-005 (SDK-Integrated Orchestrator)**: Direct response to ADR-001's context loading cost. Session resume is the key mechanism.
+- **ADR-003 (Extended Thinking)**: Cost-aware thinking budget (`budget_tokens: 5000`) shows precedent for token-cost optimization in the project.
+
+## Workshop Provenance
+
+N/A — batch discovery mode.
+
+## Sources
+
+- Luca Rossi, "Managing Context for AI Coding", Refactoring.fm (2026)
+- "Context Engineering", Unblocked blog (2026)
+- Genie-team codebase analysis (7 context systems, 6 ADRs, 18+ analysis documents)
+- Prior discovery: `docs/analysis/20260321_discover_ai_agent_memory_knowledge_management_landscape.md`

--- a/docs/analysis/20260330_spike_oauth_headless_daemon_auth.md
+++ b/docs/analysis/20260330_spike_oauth_headless_daemon_auth.md
@@ -1,0 +1,198 @@
+---
+type: spike
+question: "Can claude CLI authenticate via OAuth in headless/daemon mode?"
+verdict: Partially Feasible
+time_spent: "1 session"
+created: "2026-03-30"
+refs:
+  - docs/analysis/20260330_discover_claude_code_autonomous_orchestration_features.md
+  - docs/analysis/20260330_discover_claude_cli_oauth_authentication.md
+---
+
+# Spike: Can Claude CLI Authenticate via OAuth in Headless/Daemon Mode?
+
+**Question:** Can the `claude` CLI authenticate via OAuth without an interactive browser flow, enabling headless daemon execution with access to OAuth-gated features (Remote Control, Auto Mode, Channels)?
+
+**Verdict:** PARTIALLY FEASIBLE — API key remains the reliable headless path, but `setup-token` provides a limited OAuth bridge. The auth wall is real but has workarounds.
+
+---
+
+## Findings
+
+### Auth Hierarchy (Precedence Order)
+
+The Claude CLI resolves auth in this order:
+
+1. Cloud provider environment variables (Bedrock/Vertex)
+2. `ANTHROPIC_AUTH_TOKEN` (OAuth token, passed as env var)
+3. `ANTHROPIC_API_KEY` (API key)
+4. `apiKeyHelper` script (dynamic key provisioning)
+5. Subscription OAuth (interactive login, tokens in macOS Keychain or `~/.claude/.credentials.json`)
+
+### Three Auth Paths for Headless Execution
+
+| Path | Mechanism | Token Lifetime | Features Unlocked | Reliability |
+|------|-----------|---------------|-------------------|-------------|
+| **API Key** | `ANTHROPIC_API_KEY` env var | Indefinite | `claude -p`, `/loop`, scheduled tasks, GitHub Actions | **High** — battle-tested, no refresh issues |
+| **Setup Token** | `claude setup-token` → `sk-ant-oat01-...` | 1 year | `claude -p`, `/loop`, scheduled tasks | **Medium** — requires manual `.claude.json` workaround (Issue #8938) |
+| **OAuth Token** | `ANTHROPIC_AUTH_TOKEN` env var | ~10-15 min (unrefreshed) | Same as setup-token | **Low** — token refresh broken in `-p` mode (Issues #28827, #12447, #21765) |
+
+### What Each Path Cannot Do
+
+| Feature | API Key | Setup Token | Full OAuth |
+|---------|---------|-------------|-----------|
+| Remote Control | No | No (inference-only scope) | **Yes** |
+| Channels | No | Unclear (likely no) | **Yes** |
+| Auto Mode | No | Unclear | **Yes** |
+| Dispatch | No | No | **Yes** (Desktop only) |
+| `claude -p` batch | **Yes** | **Yes** | **Yes** |
+| `/loop` session-scoped | **Yes** | **Yes** | **Yes** |
+| Scheduled Tasks (desktop) | **Yes** | **Yes** | **Yes** |
+| Scheduled Tasks (cloud) | **Yes** | **Yes** | **Yes** |
+| GitHub Actions | **Yes** | **Yes** | N/A |
+
+### The `setup-token` Workaround
+
+`claude setup-token` generates a 1-year inference-only OAuth token for headless use:
+
+```bash
+claude setup-token
+# Outputs: sk-ant-oat01-...
+```
+
+**Current bug (Issue #8938):** The token alone doesn't work — you must also manually create `~/.claude.json`:
+```json
+{
+  "hasCompletedOnboarding": true,
+  "oauthAccount": {
+    "emailAddress": "user@example.com",
+    "organizationName": "your-org"
+  }
+}
+```
+
+**Scope limitation:** `setup-token` creates an **inference-only** token. It cannot access features that require full OAuth session scope (Remote Control, Channels).
+
+### The `apiKeyHelper` Pattern
+
+For credential rotation without hardcoded keys:
+```json
+{
+  "apiKeyHelper": {
+    "command": "/path/to/script",
+    "timeout_ms": 5000
+  }
+}
+```
+
+The helper script is called before each API request. It can fetch from vaults (1Password, AWS Secrets Manager, etc.) and rotate credentials. This is the recommended production pattern for daemon execution with API keys.
+
+### Agent SDK Auth Model
+
+The `@anthropic-ai/claude-agent-sdk` explicitly requires `ANTHROPIC_API_KEY`:
+
+> "The Agent SDK does not allow third-party developers to offer claude.ai login or rate limits."
+
+`CLAUDE_CODE_OAUTH_TOKEN` works as an undocumented env var but Issue #6536 was closed NOT_PLANNED — Anthropic does not intend to support OAuth in the SDK.
+
+---
+
+## Impact on Genie Team
+
+### Current State
+
+Genie Team uses `ANTHROPIC_API_KEY` via environment variable. The shell orchestrator (`scripts/genies`) and TypeScript SDK (`src/core/phase-executor.ts`) both inherit auth from the environment. The `--auth oauth|apikey` flag is spec'd but not yet wired in the shell script.
+
+Your system has `ANTHROPIC_API_KEY` set in `~/.zshrc` → API key billing mode.
+
+### What This Means for Feature Adoption
+
+The three features identified as high/medium priority in the orchestration discovery:
+
+1. **Auto Mode** — **Blocked.** Requires full OAuth. API key and `setup-token` don't qualify. No workaround.
+
+2. **Remote Control** — **Blocked.** Requires full OAuth session scope. `setup-token` is inference-only. No workaround.
+
+3. **Channels** — **Blocked.** Requires full OAuth. No confirmed workaround.
+
+4. **Desktop Scheduled Tasks** — **Available.** Works with API key. Already accessible.
+
+5. **Cloud Scheduled Tasks** — **Available.** Works with API key. Already accessible.
+
+6. **`/loop`** — **Available.** Works with API key. Already used.
+
+### The Hybrid Model
+
+A practical architecture emerges:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  INTERACTIVE (Human-supervised)                      │
+│  Auth: OAuth (interactive login)                     │
+│  Features: Remote Control, Auto Mode, Channels       │
+│  Use: Supervised genie sessions, mobile monitoring   │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│  HEADLESS (Daemon/CI/CD)                             │
+│  Auth: API Key (via ANTHROPIC_API_KEY or apiKeyHelper)│
+│  Features: claude -p, /loop, scheduled tasks         │
+│  Use: Autonomous genies, batch execution, daemon     │
+└─────────────────────────────────────────────────────┘
+```
+
+These are **not mutually exclusive** — the same machine can run both:
+- Interactive sessions with OAuth (get Remote Control, Auto Mode)
+- Daemon processes with API key (reliable headless execution)
+
+The `--auth` flag in genie-team's spec (AC-3) was already designed for this: `--auth oauth` unsets `ANTHROPIC_API_KEY` to force OAuth, `--auth apikey` requires it.
+
+---
+
+## Risks
+
+1. **OAuth token refresh bug is a blocker for unified auth.** Even if you wanted OAuth everywhere, the `-p` mode refresh bug (Issues #28827/#12447) makes it unreliable for long-running daemon processes. API key has no such issue.
+
+2. **Auto Mode's safety benefit is unavailable to daemon mode.** The most valuable native feature (replacing `--dangerously-skip-permissions` with a classifier) requires OAuth. Daemon mode must continue using `--dangerously-skip-permissions` or `--skip-permissions`.
+
+3. **Feature bifurcation.** Interactive and headless sessions have different capability sets. This is manageable but adds complexity to documentation and user expectations.
+
+4. **Anthropic's direction is unclear.** The `setup-token` scope limitation and SDK OAuth rejection (Issue #6536) suggest Anthropic may intentionally keep premium features OAuth-gated (tied to subscription). This may not change.
+
+---
+
+## Recommendation
+
+**Accept the hybrid model. Don't fight the auth wall — work with it.**
+
+### Immediate (no code changes needed)
+
+1. **Document the hybrid auth model** as an ADR. Interactive sessions use OAuth for enhanced features. Daemon/CI uses API key for reliability.
+
+2. **Implement the `--auth` flag** in the shell orchestrator (already spec'd in AC-3, TypeScript implementation ready in `src/environment/auth.ts`).
+
+3. **Test `apiKeyHelper`** for credential rotation in daemon mode — this is the production-grade API key management pattern.
+
+### Short-term (when SDK migration completes)
+
+4. **Wire Auto Mode into interactive genie sessions** — when a user runs genies interactively with OAuth, enable Auto Mode instead of `--dangerously-skip-permissions`.
+
+5. **Add Remote Control to supervised daemon sessions** — `genies daemon --remote-control` could spawn a Remote Control server, letting the user monitor daemon progress from mobile.
+
+### Monitor
+
+6. **Watch Issue #28827** (OAuth token refresh in `-p` mode) — if fixed, `setup-token` becomes viable for daemon mode with subscription billing.
+
+7. **Watch for API key support in Auto Mode** — this would be the highest-impact change for genie-team's safety model.
+
+### Don't pursue
+
+8. **Don't try to hack OAuth into headless mode.** The `CLAUDE_CODE_OAUTH_TOKEN` path is unsupported (Issue #6536 closed NOT_PLANNED) and the refresh bug makes it unreliable. API key is the right choice for unattended execution.
+
+---
+
+## Next Steps
+
+- **Ready for `/define`** — Shape the hybrid auth model as a backlog item
+- The auth wall is understood; the workaround (hybrid model) is practical
+- No sub-spikes needed — the evidence is sufficient

--- a/docs/analysis/20260331_discover_spec_kit_deep_research.md
+++ b/docs/analysis/20260331_discover_spec_kit_deep_research.md
@@ -1,0 +1,568 @@
+---
+type: discover
+topic: "GitHub spec-kit deep research"
+reasoning_mode: deep
+status: active
+created: "2026-03-31"
+---
+
+# Opportunity Snapshot: GitHub spec-kit Deep Research
+
+## 1. Discovery Question
+
+**Original:** Research the GitHub spec-kit repository in depth -- purpose, architecture, spec format, workflow, CLI/tooling, AI integration, document types, quality gates.
+
+**Reframed:** What design decisions and patterns does spec-kit use for specification-driven development, and how do they compare to the genie-team approach?
+
+## 2. What spec-kit Is
+
+### Purpose and Philosophy
+
+spec-kit is an open-source toolkit (MIT license) from GitHub enabling **Spec-Driven Development (SDD)** -- a methodology that inverts traditional development by making specifications executable rather than aspirational. The core thesis: specifications should generate working implementations, not merely guide them.
+
+The key philosophical claim: "Specifications don't serve code -- code serves specifications." This is a power inversion where the PRD/spec becomes the generative source, and the gap between specification and implementation is eliminated rather than narrowed.
+
+**Repository:** `github/spec-kit` -- 84.1k stars, 7.2k forks (as of March 2026).
+
+**Target Audience:** Development teams using AI coding assistants who want structured specification workflows. Supports 23+ AI agents including Claude Code, GitHub Copilot, Cursor, Gemini CLI, Windsurf, and others.
+
+### Key Claim: 12 Hours to 15 Minutes
+
+The methodology document claims that traditional specification work requiring ~12 hours can be accomplished in ~15 minutes through template-based automation and structural consistency.
+
+## 3. Architecture
+
+### Technology Stack
+
+- **Language:** Python 3.11+
+- **Package Manager:** uv (Astral)
+- **CLI Framework:** Typer + Click + Rich
+- **Build System:** Hatchling
+- **Package Name:** `specify-cli` (published as `specify` command)
+- **Dependencies:** httpx, platformdirs, pyyaml, packaging, pathspec, json5, truststore
+
+### Repository Structure
+
+```
+spec-kit/
+  .devcontainer/           # Dev container config
+  .github/                 # CI workflows
+  docs/                    # Documentation site
+  extensions/              # Extension catalog system
+  media/                   # Logo/branding
+  newsletters/             # Community newsletters
+  presets/                 # Preset catalog system
+  scripts/                 # Shell utilities (branch creation, context updates)
+  src/specify_cli/         # Main CLI application
+    __init__.py
+    agents.py              # 23-agent configuration registry
+    extensions.py          # Extension lifecycle manager
+    presets.py             # Preset/template resolution
+    integrations/          # External system integrations
+  templates/               # Core templates
+    commands/              # AI agent command templates (9 commands)
+    spec-template.md
+    plan-template.md
+    tasks-template.md
+    constitution-template.md
+    checklist-template.md
+    agent-file-template.md
+    vscode-settings.json
+  tests/                   # pytest suite
+  AGENTS.md                # Agent integration docs
+  spec-driven.md           # SDD methodology guide
+  pyproject.toml
+```
+
+### Generated Project Structure
+
+When `specify init <project-name>` runs, it creates:
+
+```
+.specify/
+  memory/
+    constitution.md        # Project principles (immutable)
+  specs/
+    {branch-name}/         # One directory per feature
+      spec.md              # Feature specification
+      plan.md              # Implementation plan
+      tasks.md             # Ordered task list
+      research.md          # Phase 0 research
+      data-model.md        # Entity definitions
+      quickstart.md        # Quick reference
+      contracts/           # Interface definitions
+      checklists/          # Quality validation checklists
+  templates/
+    overrides/             # User template overrides
+  extensions/              # Installed extensions
+  extensions.yml           # Hook configuration
+  init-options.json        # Init configuration
+```
+
+### Key Architectural Patterns
+
+1. **Template-driven generation:** All documents are generated from markdown templates with placeholder syntax. Templates instruct LLM behavior (e.g., "focus on what and why, not how").
+
+2. **Script-based orchestration:** Shell scripts (Bash + PowerShell) handle branch creation, context updates, and file discovery. Commands call these scripts and parse JSON output.
+
+3. **Agent-agnostic command system:** A central `AGENT_CONFIG` dictionary maps 23 agents to their directory paths, file formats (markdown/TOML), argument syntax (`$ARGUMENTS` vs `{{args}}`), and file extensions. One template renders into agent-specific formats.
+
+4. **Four-tier template resolution:** Presets use a priority stack: project overrides > installed presets > extension templates > core templates.
+
+5. **Extension hook system:** `.specify/extensions.yml` defines before/after hooks for each command, with condition evaluation (`config.key == 'value'`, `env.VAR is set`).
+
+## 4. Spec Format
+
+### Feature Specification (spec-template.md)
+
+The spec is a flat markdown document (no YAML frontmatter) with:
+
+```markdown
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`
+**Created**: [DATE]
+**Status**: Draft
+**Input**: User description: "$ARGUMENTS"
+```
+
+**Required Sections:**
+
+| Section | Content |
+|---------|---------|
+| User Scenarios & Testing | Prioritized user stories (P1/P2/P3) with Given-When-Then acceptance scenarios |
+| Functional Requirements | FR-001 through FR-NNN with "System MUST [capability]" statements |
+| Key Entities | Data model descriptions and relationships |
+| Success Criteria | SC-001 through SC-NNN with measurable outcomes (technology-agnostic) |
+| Assumptions | Scope boundaries, user context, dependencies |
+
+**Key Design Choices:**
+
+- **No YAML frontmatter** -- purely markdown with inline metadata fields
+- **Numbered requirements** -- FR-001, SC-001 with stable keys for cross-referencing
+- **Ambiguity markers** -- `[NEEDS CLARIFICATION: specific question]` tags (max 3)
+- **Priority labels** -- P1/P2/P3 on user stories
+- **Technology-agnostic** -- specs describe WHAT, never HOW
+- **Acceptance scenarios** -- Given-When-Then format within user stories
+
+### Implementation Plan (plan-template.md)
+
+Follows the spec with technical decisions:
+
+- **Technical Context** block: language, dependencies, storage, testing framework, platform, performance goals
+- **Constitution Check** gate: validates against project principles before proceeding
+- **Three source code layout options** (single project, web app, mobile+API)
+- **Phase 0: Research** -- extracts unknowns into research.md
+- **Phase 1: Design** -- generates data-model.md, contracts/, quickstart.md
+- **Complexity Tracking** -- justification table for constitution violations
+
+### Task List (tasks-template.md)
+
+Structured task breakdown with:
+
+```
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+- **Five phases:** Setup > Foundational > User Stories (by priority) > Polish
+- **Parallel markers:** `[P]` for concurrent execution
+- **Story labels:** `[US1]`, `[US2]` for story grouping
+- **File paths required** on every task
+- **Tests precede implementation** (TDD ordering)
+
+### Constitution (constitution-template.md)
+
+Project-level governance document with:
+
+- 5+ named principles (e.g., Library-First, CLI Interface, Test-First)
+- Governance rules for compliance verification
+- Versioned with ratification date
+- Functions as "architectural compile-time checks" -- referenced in plan templates as "Phase -1 Gates"
+
+### Checklist (checklist-template.md)
+
+Quality validation with:
+- Categorized checkbox items (CHK001, CHK002...)
+- Linked to spec, plan, and implementation context
+- Generated per-feature, not global
+
+## 5. Workflow: How Specs Move Through Stages
+
+### Linear 5-Command Pipeline
+
+```
+/speckit.constitution  (once per project)
+      |
+/speckit.specify  --> spec.md
+      |
+/speckit.clarify  --> updates spec.md (optional, reduces ambiguity)
+      |
+/speckit.plan     --> plan.md + research.md + data-model.md + contracts/
+      |
+/speckit.tasks    --> tasks.md
+      |
+/speckit.implement --> code (phase-by-phase execution)
+      |
+/speckit.analyze  --> consistency report (optional, read-only)
+/speckit.checklist --> quality checklist (optional)
+```
+
+### Stage Details
+
+1. **Constitution** (project-level, one-time): Establishes immutable architectural principles. Nine articles in the reference implementation covering Library-First, CLI Interface, Test-First, Simplicity, Anti-Abstraction, Integration-First Testing.
+
+2. **Specify** (per-feature): Transforms natural language description into structured spec. Creates feature branch and directory. Generates requirements checklist. Max 3 ambiguity markers. Validates against 12 quality items (up to 3 iterations).
+
+3. **Clarify** (optional per-feature): Audits spec against 10 taxonomy categories. Asks up to 5 targeted questions (one at a time). Multiple-choice or short-phrase answers. Integrates answers into spec with `## Clarifications` section.
+
+4. **Plan** (per-feature): Reads spec + constitution. Fills technical context. Runs constitution compliance check. Executes Phase 0 (research) and Phase 1 (design). Generates data-model.md, contracts/, quickstart.md.
+
+5. **Tasks** (per-feature): Reads plan + spec. Extracts tech stack, user stories, entities. Generates phased task list with dependency ordering and parallelization.
+
+6. **Implement** (per-feature): Executes tasks phase-by-phase. Validates prerequisites (checklists, ignore files). Respects TDD ordering (tests before implementation). Tracks completion by marking `[X]` in tasks.md.
+
+7. **Analyze** (optional, read-only): Cross-artifact consistency checker. Validates spec/plan/tasks for duplications, ambiguities, coverage gaps, constitution violations. Severity levels: CRITICAL/HIGH/MEDIUM/LOW. Max 50 findings.
+
+### Feature Branch Model
+
+- Branch naming: `{number}-{feature-name}` (sequential or timestamp-based)
+- One directory per feature under `.specify/specs/{branch-name}/`
+- All artifacts co-located in feature directory
+
+### Hook System
+
+Extensions can attach before/after hooks to any command:
+- `hooks.before_specify`, `hooks.after_specify`, etc.
+- Hooks have: extension, command, enabled, optional, prompt, description, condition
+- Conditions: `config.key is set`, `config.key == 'value'`, `env.VAR is set`
+- Optional hooks prompt user; mandatory hooks auto-execute
+
+## 6. CLI Tooling
+
+### Installation
+
+```bash
+# Persistent (recommended)
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@vX.Y.Z
+
+# One-time
+uvx --from git+https://github.com/github/spec-kit.git@vX.Y.Z specify init <PROJECT_NAME>
+
+# Air-gapped (enterprise)
+pip download specify-cli --from ... && pip install specify-cli-*.whl
+```
+
+### CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `specify init <name> --ai <agent>` | Bootstrap project with agent-specific commands |
+| `specify init <name> --ai <agent> --ai-skills` | Also generate SKILL.md files |
+| `specify init <name> --ai generic --ai-commands-dir <dir>` | Generic agent support |
+
+The CLI itself is a bootstrapper -- it generates the `.specify/` directory structure and installs command templates. The actual workflow commands (`/speckit.specify`, etc.) run inside the AI agent, not as CLI subcommands.
+
+### Extension CLI
+
+| Command | Purpose |
+|---------|---------|
+| `specify ext install <path-or-zip>` | Install extension |
+| `specify ext remove <id>` | Remove extension |
+| `specify ext list` | List installed extensions |
+| `specify ext search <query>` | Search catalogs |
+
+### Preset CLI
+
+| Command | Purpose |
+|---------|---------|
+| `specify preset install <path-or-zip>` | Install preset |
+| `specify preset remove <id>` | Remove preset |
+| `specify preset list` | List installed presets |
+
+## 7. AI/LLM Integration
+
+### Agent Configuration Registry
+
+The `AGENT_CONFIG` dictionary in `agents.py` is the single source of truth for 23 agents:
+
+```python
+AGENT_CONFIG = {
+    "claude": {
+        "dir": ".claude/commands",
+        "format": "markdown",
+        "args": "$ARGUMENTS",
+        "extension": ".md"
+    },
+    "gemini": {
+        "dir": ".gemini/commands",
+        "format": "toml",
+        "args": "{{args}}",
+        "extension": ".toml"
+    },
+    "copilot": {
+        "dir": ".github/agents",
+        "format": "markdown",
+        "args": "$ARGUMENTS",
+        "extension": ".agent.md"
+    },
+    # ... 20 more agents
+}
+```
+
+### How It Works with Claude Code
+
+1. `specify init myproject --ai claude` copies command templates to `.claude/commands/`:
+   - `speckit.specify.md`
+   - `speckit.plan.md`
+   - `speckit.tasks.md`
+   - `speckit.implement.md`
+   - `speckit.clarify.md`
+   - `speckit.analyze.md`
+   - `speckit.checklist.md`
+   - `speckit.constitution.md`
+   - `speckit.taskstoissues.md`
+
+2. User invokes via Claude Code slash commands: `/speckit.specify Build a todo app`
+
+3. The command template is a detailed prompt that instructs the LLM how to:
+   - Parse user input
+   - Run prerequisite scripts
+   - Load templates
+   - Generate structured output
+   - Validate quality
+   - Report results
+
+4. Templates reference script paths (`.specify/scripts/`) for branch creation, context updates, file discovery.
+
+### Agent-File Template
+
+An auto-generated documentation file (like AGENTS.md or CLAUDE.md) that consolidates:
+- Active technologies from all plan.md files
+- Project structure from plan specifications
+- CLI commands for active tech stacks
+- Code style guidelines per language
+- Recent feature changes
+
+This creates a self-updating project context file for the AI agent.
+
+## 8. Document Types
+
+| Document | Location | Purpose | Lifecycle |
+|----------|----------|---------|-----------|
+| Constitution | `.specify/memory/constitution.md` | Immutable project principles | Created once, rarely amended |
+| Feature Spec | `.specify/specs/{branch}/spec.md` | What to build (requirements) | Created by /specify, refined by /clarify |
+| Implementation Plan | `.specify/specs/{branch}/plan.md` | How to build it (technical) | Created by /plan |
+| Research | `.specify/specs/{branch}/research.md` | Phase 0 unknowns resolved | Created by /plan |
+| Data Model | `.specify/specs/{branch}/data-model.md` | Entity definitions | Created by /plan |
+| Contracts | `.specify/specs/{branch}/contracts/*.md` | Interface definitions | Created by /plan |
+| Quick Start | `.specify/specs/{branch}/quickstart.md` | Developer reference | Created by /plan |
+| Task List | `.specify/specs/{branch}/tasks.md` | Ordered implementation tasks | Created by /tasks |
+| Checklists | `.specify/specs/{branch}/checklists/*.md` | Quality validation | Created by /specify, /checklist |
+| Analysis Report | (stdout) | Consistency findings | Created by /analyze (read-only) |
+| Agent File | `.claude/CLAUDE.md` (or equivalent) | AI context document | Auto-regenerated |
+| Extension Config | `.specify/extensions.yml` | Hook configuration | Modified by extension install |
+
+## 9. Quality Gates
+
+### Spec Quality Validation (/specify)
+
+- 12-item quality checklist generated automatically
+- Validates content, requirements, and readiness
+- Up to 3 validation iterations
+- Maximum 3 `[NEEDS CLARIFICATION]` markers
+- Success criteria must be measurable, technology-agnostic, user-focused
+
+### Constitution Compliance (/plan)
+
+- "Phase -1 Gates" -- checked before Phase 0 research and after Phase 1 design
+- Any MUST principle violation is automatically CRITICAL
+- Complexity justification table required for exceptions
+
+### Cross-Artifact Consistency (/analyze)
+
+- Read-only checker across spec/plan/tasks
+- Six detection passes: duplication, ambiguity, underspecification, constitution alignment, coverage gaps, inconsistency
+- Four severity levels: CRITICAL, HIGH, MEDIUM, LOW
+- Maximum 50 findings per run
+- Coverage metrics: requirements with zero tasks, orphan tasks
+- Semantic model built from FR/SC numbering
+
+### Checklist Prerequisites (/implement)
+
+- Validates checklist completion before implementation begins
+- Incomplete checklists prompt user confirmation
+
+### Extension Manifest Validation
+
+- Schema version enforcement
+- Semantic versioning required
+- Command naming pattern: `speckit.{extension}.{command}`
+- Namespace conflict detection (cannot shadow core commands)
+- Path traversal prevention in ZIP extraction
+- HTTPS enforcement for catalog URLs
+
+## 10. Extension and Preset System
+
+### Extensions
+
+Add new capabilities (commands, hooks) without modifying core:
+
+- **Manifest:** `extension.yml` with schema version, metadata, provides (commands, hooks)
+- **Registry:** `.registry` JSON file tracks installed extensions with priority
+- **Catalogs:** Multi-catalog support with official + community catalogs
+- **Hooks:** Before/after hooks on any core command
+- **40+ community extensions** including: MAQA (QA with CI gates), Jira/Linear/Azure DevOps integrations, code review, test traceability, health diagnostics, DocGuard
+
+### Presets
+
+Customize templates without adding features:
+
+- **Purpose:** Terminology changes, compliance requirements, domain-specific formats
+- **Resolution:** Four-tier stack (project overrides > presets > extensions > core)
+- **No new commands** -- presets only swap templates
+- **Use cases:** Compliance (SOC2, HIPAA), domain language, team conventions
+
+## 11. Key Differences from Genie-Team
+
+### Shared Foundation: Specs as Connective Tissue to Code
+
+Both systems use specs as **direct connective tissue to code generation**, not as passive documentation. The spec-to-code chain is structurally similar:
+
+| Step | spec-kit | genie-team |
+|------|----------|------------|
+| **Spec → requirement** | FR-001: "System MUST..." | AC-1: description in frontmatter |
+| **Requirement → test target** | Task references FR-001 | Test describes AC-1: `describe("AC-1: ...")` |
+| **Test → implementation** | /implement executes tasks | /deliver TDD red-green-refactor |
+| **Implementation → verification** | /checklist validates CHK items | /discern evaluates each AC → met/unmet |
+
+The philosophical difference is NOT "generates code vs describes behavior" — both generate code from specs. The difference is **connection lifetime and knowledge accumulation**.
+
+### The Real Axis: Disposable Blueprints vs Persistent Connective Tissue
+
+**spec-kit** treats specs as **disposable blueprints**. A spec lives in `.specify/specs/{branch}/`, drives one feature's code generation, and is effectively done when the branch merges. The next feature touching the same capability starts with a blank spec — no memory of prior design decisions, implementation evidence, or review verdicts.
+
+**genie-team** treats specs as **persistent connective tissue**. A spec at `docs/specs/{domain}/{capability}.md` survives every feature that touches it, accumulating knowledge across the lifecycle:
+
+```
+After /define:  acceptance_criteria (all pending)
+After /design:  + Design Constraints section
+After /deliver: + Implementation Evidence (test paths, source paths)
+After /discern: + Review Verdict, AC statuses → met
+After next feature: + new ACs appended, behavioral delta documented, cycle repeats
+```
+
+### Comparison Table
+
+| Dimension | spec-kit | genie-team |
+|-----------|----------|------------|
+| **Spec-to-code relationship** | 1:1 (one spec, one feature) | 1:many (one spec, many features over time) |
+| **Spec lifecycle** | Born with feature branch, dies on merge | Permanent, accumulates across features |
+| **Cross-feature learning** | None — each feature starts fresh | Spec retains constraints, evidence, verdicts |
+| **Behavioral delta** | No concept (specs don't persist) | Explicit: current behavior vs proposed changes |
+| **AC traceability** | FR-001 → task → code (then gone) | AC-1 → test → code → verdict (permanent) |
+| **Spec format** | Flat markdown, no YAML frontmatter, FR/SC numbering | YAML frontmatter with structured AC list, body sections |
+| **Organization** | By feature branch (temporal) | By domain > capability (product architecture) |
+| **Workflow** | Linear pipeline (specify > plan > tasks > implement) | Cyclic (discover > define > design > deliver > discern) |
+| **Discovery phase** | None — starts with /specify | Scout explores problem space before defining |
+| **Review phase** | /analyze (read-only consistency check) | /discern (Critic with accept/reject verdict + AC status updates) |
+| **Integration verification** | None | Mandatory wiring check: "is this reachable from running system, not just mock-passing?" |
+| **Constitution** | Project-wide immutable principles with enforcement gates | No equivalent (CLAUDE.md + rules files serve partial role) |
+| **AI integration** | 23 agents via command templates | Claude Code only, via agents + commands + skills |
+| **Extension system** | Full plugin architecture (manifests, catalogs, hooks) | No plugin system (skills are static) |
+| **CLI** | Python CLI (`specify`) for bootstrapping | Shell script (`install.sh`) for copying files |
+| **Ambiguity handling** | /clarify command with structured Q&A | Scout discovery surfaces assumptions |
+| **Task generation** | Automated from plan (/tasks) | Implicit in /deliver (TDD drives task order) |
+| **Research phase** | Phase 0 embedded in /plan (unknowns → research.md) | Separate /discover step before /define |
+| **Project principles** | Constitution with numbered articles and violation justification | Rules files, CLAUDE.md |
+| **Maturity** | 84k stars, 40+ extensions, multi-agent | Internal project, Claude Code only |
+
+### Where spec-kit Is Stronger
+
+1. **Constitution guardrails** — Immutable principles enforced as "Phase -1 gates" during planning, with structured violation justification (why needed + simpler alternative rejected). NON-NEGOTIABLE markers create hard gates with no escape hatch.
+2. **Extension/preset architecture** — Four-tier template resolution, manifest validation, hook system, multi-catalog support. 40+ community extensions.
+3. **Multi-agent support** — 23 agents via clean `AGENT_CONFIG` registry. One template renders into agent-specific formats.
+4. **Automated task decomposition** — /tasks generates ordered, parallelizable implementation tasks with file paths and dependency markers from plans.
+5. **Structured ambiguity reduction** — /clarify uses 10 taxonomy categories with targeted Q&A (max 5 questions).
+6. **Cross-artifact consistency** — /analyze validates spec/plan/tasks for duplications, coverage gaps, and constitution violations with severity levels.
+7. **Explicit research phase** — Phase 0 in /plan extracts unknowns into research.md before design begins.
+
+### Where genie-team Is Stronger
+
+1. **Persistent spec knowledge** — Specs accumulate design constraints, implementation evidence, and review verdicts across features. Domain READMEs auto-generated with AC status counts.
+2. **Discovery phase** — Scout explores problem space, surfaces assumptions, uses JTBD/Teresa Torres frameworks before anyone writes a spec.
+3. **Review with teeth** — Critic produces accept/reject verdicts with AC-level status tracking that updates the persistent spec. Not just consistency checking.
+4. **Behavioral delta tracking** — When modifying existing capability, backlog documents current vs proposed behavior against the persistent spec.
+5. **Integration wiring verification** — Mandatory check that implementation is reachable from the running system, not just passing mock tests.
+6. **Cyclic workflow** — 7 D's allow iteration (discern → deliver rework, diagnose → tidy maintenance). spec-kit is strictly linear.
+7. **Maintenance cycle** — /diagnose + /tidy for ongoing codebase health. spec-kit has no post-implementation workflow.
+8. **Problem-first framing** — Shaper reframes solution-loaded requests as problems with appetite boundaries.
+
+## 12. Assumptions & Evidence
+
+| Assumption | Type | Confidence | Evidence For | Evidence Against |
+|------------|------|------------|--------------|------------------|
+| spec-kit's linear pipeline suits greenfield projects well | Value | High | Workflow is explicitly specify-first; 84k stars indicate adoption | No discovery phase limits applicability to well-understood problems |
+| Constitution model prevents architectural drift | Feasibility | Moderate | Phase -1 gates in plan template; constitution checks are mandatory | Constitution is per-project, one-time -- may not evolve with project |
+| 23-agent support is a significant adoption driver | Value | High | Broadest agent coverage in this space; generic fallback available | Quality may vary across agents -- each just gets template rendering |
+| Extension system adds meaningful ecosystem value | Value | Moderate | 40+ community extensions; full manifest/catalog/hook architecture | Extension quality is unverified; community catalog is "discovery only" |
+| Template-driven LLM guidance produces consistent specs | Usability | Moderate | Templates encode anti-patterns, clarification limits, quality checklists | LLM compliance with complex templates varies; no automated validation of output |
+| Feature-branch-scoped specs are sufficient for knowledge retention | Value | Low | Clean per-feature isolation | No persistent capability knowledge -- specs die with features; no cross-feature learning |
+
+### Evidence Grade Justifications
+
+- **84k stars / 7.2k forks:** Strong signal for adoption but does not prove production usage depth. Star counts can inflate from trending/HN effects. Still, this is very high for a dev-tools repo.
+- **23-agent support:** Verified by reading `AGENT_CONFIG` dictionary in `agents.py`. Each agent has directory, format, args, and extension mapped. Coverage is real but depth (how well each agent handles the prompts) is unverified.
+- **40+ extensions:** Claimed in README and referenced in catalog system. `catalog.community.json` exists but individual extension quality is not assessed.
+- **No YAML frontmatter in specs:** Confirmed by reading `spec-template.md`. Metadata is inline markdown fields (`**Status**: Draft`), not structured data.
+
+## 13. Technical Signals
+
+- **Feasibility:** N/A (research-only task)
+- **Constraints:** spec-kit requires Python 3.11+ and uv; genie-team is shell+markdown
+- **Needs Architect spike:** No
+
+## 14. Opportunity Areas (Unshaped)
+
+### Genie-team Differentiators to Articulate
+
+1. **Persistent spec connective tissue** -- spec-kit's specs are disposable blueprints that die with the feature branch. Genie-team's specs accumulate design constraints, implementation evidence, and review verdicts across every feature that touches a capability. This is a fundamental architectural advantage for long-lived products — worth making explicit in positioning.
+
+2. **Discovery-first workflow** -- spec-kit assumes the problem is understood and starts at "specify." Genie-team's Scout explores the problem space before anyone writes a spec. For ambiguous or novel work, this prevents building the wrong thing.
+
+3. **Review-as-verification** -- spec-kit's /analyze is read-only consistency checking. Genie-team's /discern evaluates whether code actually satisfies each AC, updates spec statuses, and gates on integration wiring. The feedback loop has teeth.
+
+### Patterns Worth Adopting from spec-kit
+
+4. **Constitution guardrails** -- The immutable-principles-as-gates model with structured violation justification (why needed + simpler alternative rejected) and NON-NEGOTIABLE markers. Could be implemented as a constitution document checked during `/design` and `/deliver`, complementing existing rules files. Low effort, high guardrail value.
+
+5. **Structured clarify step** -- /clarify uses 10 taxonomy categories to systematically reduce ambiguity with targeted Q&A (max 5 questions). Could slot between `/define` and `/design` to catch underspecified shaped contracts before design begins. Low effort, reduces rework.
+
+6. **Cross-artifact consistency check** -- /analyze validates spec/plan/tasks for duplications, coverage gaps, and constitution violations with severity levels. An equivalent for genie-team could validate backlog items, specs, and designs for drift. Medium effort, catches silent divergence.
+
+7. **Explicit research phase in design** -- spec-kit's Phase 0 in /plan extracts unknowns into research.md before design begins. Currently genie-team handles this via separate /discover or /spike, but embedding a research extraction step directly in /design could ensure unknowns are surfaced even when discovery is skipped.
+
+### Patterns to Study for Future
+
+8. **Extension/preset architecture** -- Four-tier template resolution, manifest validation, hook system, multi-catalog support. Reference architecture if genie-team ever needs community extensibility. High effort, premature until core workflow stabilizes.
+
+9. **Multi-agent command registry** -- `AGENT_CONFIG` registry + template rendering per agent. Reference pattern if genie-team ever targets agents beyond Claude Code. High effort, high adoption impact, but premature.
+
+10. **Automated task decomposition** -- /tasks generates ordered, parallelizable tasks from plans. Tension with genie-team's appetite-bounded philosophy, but worth considering as an optional step for well-understood features where manual shaping adds no value.
+
+## 15. Evidence Gaps
+
+- **Production usage data:** No case studies, usage metrics, or testimonials found beyond star count.
+- **Extension quality:** 40+ extensions claimed but individual quality, maintenance status, and adoption unknown.
+- **Agent parity:** Whether all 23 agents produce equivalent quality output from the same templates is unverified.
+- **Brownfield effectiveness:** Methodology guide mentions brownfield but no evidence of how well it works for existing codebases.
+- **Team adoption friction:** No data on how teams adopt SDD -- onboarding cost, learning curve, resistance patterns.
+- **Spec evolution:** No mechanism found for spec evolution across features -- each feature starts fresh with no cross-pollination.
+
+## 16. Routing Recommendation
+
+- [x] **Ready for Navigator** -- Research complete. Findings are comprehensive enough for comparison or strategic decisions.
+- [ ] Continue Discovery
+- [ ] Ready for Shaper
+- [ ] Needs Architect Spike
+
+**Rationale:** This was a pure research task. The Opportunity Snapshot provides comprehensive coverage of spec-kit's architecture, format, workflow, and integration patterns. All eight requested dimensions are addressed. The comparison table and opportunity areas provide the material needed for whatever comparison the Navigator intends.


### PR DESCRIPTION
## Summary
Captures six discovery/spike artifacts produced over the last two weeks. Docs only — no behavior changes.

- \`20260321_discover_ai_agent_memory_knowledge_management_landscape.md\`
- \`20260330_discover_claude_cli_oauth_authentication.md\`
- \`20260330_discover_claude_code_autonomous_orchestration_features.md\`
- \`20260330_discover_context_engineering_improvements.md\`
- \`20260330_spike_oauth_headless_daemon_auth.md\`
- \`20260331_discover_spec_kit_deep_research.md\`

These had been sitting untracked in the working tree; landing them ensures the document trail reflects the research that informed recent direction (autonomy, OAuth, context engineering, spec-kit).

## Test plan
- [ ] Frontmatter validation passes (already enforced by pre-commit)
- [ ] No cross-reference breakage (already enforced by pre-commit)
- [ ] Files render in GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)